### PR TITLE
fix join use nulls and support post join filter

### DIFF
--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -187,6 +187,7 @@ public:
     void setKind(ASTTableJoin::Kind kind) { table_join.kind = kind; }
     ASTTableJoin::Strictness strictness() const { return table_join.strictness; }
     void setStrictness(ASTTableJoin::Strictness strictness) { table_join.strictness = strictness; }
+    void setColumnsFromJoinedTable(NamesAndTypesList columns_from_joined_table_) {columns_from_joined_table = columns_from_joined_table_;}
     bool sameStrictnessAndKind(ASTTableJoin::Strictness, ASTTableJoin::Kind) const;
     const SizeLimits & sizeLimits() const { return size_limits; }
     VolumePtr getTemporaryVolume() { return tmp_volume; }

--- a/utils/local-engine/Common/DebugUtils.cpp
+++ b/utils/local-engine/Common/DebugUtils.cpp
@@ -4,6 +4,7 @@
 #include <Functions/FunctionHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnNullable.h>
 
 namespace debug
 {
@@ -12,7 +13,7 @@ void headBlock(const DB::Block & block, size_t count)
 {
     std::cerr << "============Block============" << std::endl;
     // print header
-    for (auto name : block.getNames())
+    for (const auto& name : block.getNames())
     {
         std::cerr << name << "\t";
     }
@@ -24,38 +25,50 @@ void headBlock(const DB::Block & block, size_t count)
         {
             const auto type = block.getByPosition(column).type;
             auto col = block.getByPosition(column).column;
-            DB::WhichDataType which(type);
-            if (which.isUInt())
+            auto nested_col = col;
+            DB::DataTypePtr nested_type = type;
+            if (const auto *nullable = DB::checkAndGetDataType<DB::DataTypeNullable>(type.get()))
             {
-                auto value = col->getUInt(row);
+                nested_type = nullable->getNestedType();
+                const auto *nullable_column = DB::checkAndGetColumn<DB::ColumnNullable>(*col);
+                nested_col = nullable_column->getNestedColumnPtr();
+            }
+            DB::WhichDataType which(nested_type);
+            if (col->isNullAt(row))
+            {
+                std::cerr << "null" << "\t";
+            }
+            else if (which.isUInt())
+            {
+                auto value = nested_col->getUInt(row);
                 std::cerr << std::to_string(value) << "\t";
             }
             else if (which.isString())
             {
-                auto value = DB::checkAndGetColumn<DB::ColumnString>(*col)->getDataAt(row).toString();
+                auto value = DB::checkAndGetColumn<DB::ColumnString>(*nested_col)->getDataAt(row).toString();
                 std::cerr << value << "\t";
             }
             else if (which.isInt())
             {
-                auto value = col->getInt(row);
+                auto value = nested_col->getInt(row);
                 std::cerr << std::to_string(value) << "\t";
             }
             else if (which.isFloat32())
             {
-                auto value = col->getFloat32(row);
+                auto value = nested_col->getFloat32(row);
                 std::cerr << std::to_string(value) << "\t";
             }
             else if (which.isFloat64())
             {
-                auto value = col->getFloat64(row);
+                auto value = nested_col->getFloat64(row);
                 std::cerr << std::to_string(value) << "\t";
             }
             else if (which.isDate())
             {
-                auto * date_type = DB::checkAndGetDataType<DB::DataTypeDate>(type.get());
+                const auto * date_type = DB::checkAndGetDataType<DB::DataTypeDate>(nested_type.get());
                 String date_string;
                 DB::WriteBufferFromString wb(date_string);
-                date_type->getSerialization(DB::ISerialization::Kind::DEFAULT)->serializeText(*col, row, wb, {});
+                date_type->getSerialization(DB::ISerialization::Kind::DEFAULT)->serializeText(*nested_col, row, wb, {});
                 std::cerr << date_string.substr(0, 10) << "\t";
             }
             else
@@ -79,9 +92,13 @@ void headColumn(const DB::ColumnPtr column, size_t count)
     for (size_t row = 0; row < std::min(count, column->size()); ++row)
     {
         auto type = column->getDataType();
-        auto col = column;
+        const auto& col = column;
         DB::WhichDataType which(type);
-        if (which.isUInt())
+        if (col->isNullAt(row))
+        {
+            std::cerr << "null" << "\t";
+        }
+        else if (which.isUInt())
         {
             auto value = col->getUInt(row);
             std::cerr << std::to_string(value) << std::endl;

--- a/utils/local-engine/Common/common.cpp
+++ b/utils/local-engine/Common/common.cpp
@@ -28,6 +28,7 @@ void init()
     // disable global context initialized
     local_engine::SerializedPlanParser::global_context->setBackgroundExecutorsInitialized(true);
     local_engine::SerializedPlanParser::global_context->makeGlobalContext();
+    local_engine::SerializedPlanParser::global_context->setSetting("join_use_nulls", true);
     local_engine::SerializedPlanParser::global_context->setConfig(local_engine::SerializedPlanParser::config);
     local_engine::SerializedPlanParser::global_context->setPath("/");
     local_engine::Logger::initConsoleLogger();


### PR DESCRIPTION
当join类型为left join时，右表需要转换为nullable的类型。
通过在join之后增加filter算子临时支持join的on condition，当join为left join时数据存在问题，后续需要修改为on clause的实现