### PR TITLE
Using NewWeakGlobalRef instead of NewGlobalRef

### DIFF
--- a/utils/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
+++ b/utils/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
@@ -14,7 +14,6 @@ void WriteBufferFromJavaOutputStream::nextImpl()
         throw std::runtime_error("get env error");
     }
 
-    Position current_pos = this->working_buffer.begin();
     size_t bytes_write = 0;
     while (offset() - bytes_write > 0)
     {
@@ -32,8 +31,8 @@ WriteBufferFromJavaOutputStream::WriteBufferFromJavaOutputStream(JavaVM * vm_, j
     {
         throw std::runtime_error("get env error");
     }
-    buffer = static_cast<jbyteArray>(env->NewGlobalRef(buffer_));
-    output_stream = env->NewGlobalRef(output_stream_);
+    buffer = static_cast<jbyteArray>(env->NewWeakGlobalRef(buffer_));
+    output_stream = env->NewWeakGlobalRef(output_stream_);
     buffer_size = env->GetArrayLength(buffer);
 }
 void WriteBufferFromJavaOutputStream::finalizeImpl()
@@ -50,7 +49,7 @@ WriteBufferFromJavaOutputStream::~WriteBufferFromJavaOutputStream()
 {
     JNIEnv * env;
     vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_8);
-    env->DeleteGlobalRef(output_stream);
-    env->DeleteGlobalRef(buffer);
+    env->DeleteWeakGlobalRef(output_stream);
+    env->DeleteWeakGlobalRef(buffer);
 }
 }

--- a/utils/local-engine/local_engine_jni.cpp
+++ b/utils/local-engine/local_engine_jni.cpp
@@ -99,7 +99,7 @@ void JNI_OnUnload(JavaVM * vm, void * reserved)
 }
 //static SharedContextHolder shared_context;
 
-void Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv *, jobject)
+void Java_io_glutenproject_vectorized_ExpressionEvaluatorJniWrapper_nativeInitNative(JNIEnv *, jobject, jbyteArray)
 {
     try
     {


### PR DESCRIPTION
Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehaviour in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
