### PR TITLE
When using optimized version of `ParquetBlockInputFormat`, coredump happends 

### DIFF
--- a/utils/local-engine/tests/CMakeLists.txt
+++ b/utils/local-engine/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ target_compile_options(benchmark PUBLIC
 target_include_directories(unit_tests_local_engine PRIVATE
         ${GTEST_INCLUDE_DIRS}/include
         )
-include_directories(benchmark_local_engine SYSTEM PUBLIC ${FETCH_CONTENT_SOURCE_DIR_GOOGLEBENCHMARK}/include)
+include_directories(benchmark_local_engine SYSTEM PUBLIC ${FETCH_CONTENT_SOURCE_DIR_GOOGLEBENCHMARK}/include ${ClickHouse_SOURCE_DIR}/utils/local-engine)
 
 target_link_libraries(unit_tests_local_engine PRIVATE ${LOCALENGINE_SHARED_LIB} _gtest_all)
 target_link_libraries(benchmark_local_engine PRIVATE ${LOCALENGINE_SHARED_LIB} benchmark::benchmark)

--- a/utils/local-engine/tests/benchmark_local_engine.cpp
+++ b/utils/local-engine/tests/benchmark_local_engine.cpp
@@ -1518,11 +1518,20 @@ static void BM_ParquetReadString(benchmark::State& state)
 
     for (auto _ : state)
     {
+        auto files_info = std::make_shared<FilesInfo>();
+        files_info->files = {file};
+
+        auto builder = std::make_unique<QueryPipelineBuilder>();
+        builder->init(Pipe(std::make_shared<BatchParquetFileSource>(files_info, header, SerializedPlanParser::global_context)));
+        auto pipeline = QueryPipelineBuilder::getPipeline(std::move(*builder));
+        auto reader = PullingPipelineExecutor(pipeline);
+        /*
         auto in = std::make_unique<ReadBufferFromFile>(file);
         auto format = std::make_shared<ParquetBlockInputFormat>(*in, header, format_settings);
         auto pipeline = QueryPipeline(std::move(format));
         auto reader = std::make_unique<PullingPipelineExecutor>(pipeline);
-        while (reader->pull(res))
+        */
+        while (reader.pull(res))
         {
             debug::headBlock(res);
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When using optimized version of `ParquetBlockInputFormat`, coredump happends 

``` cpp

static void BM_ParquetReadString(benchmark::State& state)
{
    using namespace DB;
    auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
    Block header{
        // ColumnWithTypeAndName(DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "l_returnflag"),
        // ColumnWithTypeAndName(DataTypeString().createColumn(), std::make_shared<DataTypeString>(), "l_linestatus")
        ColumnWithTypeAndName(type->createColumn(), type, "l_returnflag"),
        ColumnWithTypeAndName(type->createColumn(), type, "l_linestatus")
    };
    std::string file
        = "/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem/part-00000-d08071cb-0dfa-42dc-9198-83cb334ccda3-c000.snappy.parquet";
    FormatSettings format_settings;
    Block res;

    for (auto _ : state)
    {
        auto in = std::make_unique<ReadBufferFromFile>(file);
        auto format = std::make_shared<ParquetBlockInputFormat>(*in, header, format_settings);
        auto pipeline = QueryPipeline(std::move(format));
        auto reader = std::make_unique<PullingPipelineExecutor>(pipeline);
        while (reader->pull(res))
        {
            debug::headBlock(res);
        }
    }
}
```


core stack 
```
(gdb) bt 
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f2a52318859 in __GI_abort () at abort.c:79
#2  0x00007f2a68c02306 in abort_message (format=<optimized out>) at ./contrib/libcxxabi/src/abort_message.cpp:78
#3  0x00007f2a68c1a8af in demangling_terminate_handler () at ./contrib/libcxxabi/src/cxa_default_handlers.cpp:62
#4  0x00007f2a68c1a743 in std::__terminate (func=0x2) at ./contrib/libcxxabi/src/cxa_handlers.cpp:59
#5  0x00007f2a68c1a6b8 in std::terminate () at ./contrib/libcxxabi/src/cxa_handlers.cpp:88
#6  0x00007f2a68ba350e in std::rethrow_exception (p=...) at ./contrib/libcxx/src/support/runtime/exception_pointer_cxxabi.ipp:70
#7  0x00007f2a6552ba1a in DB::PipelineExecutor::executeStep (this=<optimized out>, yield_flag=0x7ffec689b460) at ./src/Processors/Executors/PipelineExecutor.cpp:123
#8  0x00007f2a65538458 in DB::PullingPipelineExecutor::pull (this=0x7ffec689b460, chunk=...) at ./src/Processors/Executors/PullingPipelineExecutor.cpp:50
#9  0x00007f2a655386ec in DB::PullingPipelineExecutor::pull (this=0x7ffec689b460, block=...) at ./src/Processors/Executors/PullingPipelineExecutor.cpp:61
#10 0x000000000023d59b in BM_ParquetRead (state=...) at ./utils/local-engine/tests/benchmark_local_engine.cpp:234
#11 0x0000000000257ea3 in benchmark::internal::BenchmarkInstance::Run (this=0x7f2a51437f00, iters=<optimized out>, thread_id=<optimized out>, timer=<optimized out>, manager=<optimized out>, perf_counters_measurement=<optimized out>)
    at ./build_gcc/_deps/googlebenchmark-src/src/benchmark_api_internal.cc:89
#12 0x00000000002589b7 in benchmark::internal::(anonymous namespace)::RunInThread (b=0x7ffec689a9a0, iters=0, thread_id=1379111307, thread_id@entry=0, manager=0x7f2a51467c00, perf_counters_measurement=<optimized out>)
    at ./build_gcc/_deps/googlebenchmark-src/src/benchmark_runner.cc:126
#13 0x000000000025856d in benchmark::internal::BenchmarkRunner::DoNIterations (this=this@entry=0x7f2a51438180) at ./build_gcc/_deps/googlebenchmark-src/src/benchmark_runner.cc:191
#14 0x0000000000258f40 in benchmark::internal::BenchmarkRunner::DoOneRepetition (this=0x7f2a51438180) at ./build_gcc/_deps/googlebenchmark-src/src/benchmark_runner.cc:283
#15 0x000000000024b664 in benchmark::internal::(anonymous namespace)::RunBenchmarks (benchmarks=..., display_reporter=0x7f2a5153c000, file_reporter=0x0) at ./build_gcc/_deps/googlebenchmark-src/src/benchmark.cc:350
#16 benchmark::RunSpecifiedBenchmarks (display_reporter=0x7f2a5153c000, display_reporter@entry=0x0, file_reporter=file_reporter@entry=0x0) at ./build_gcc/_deps/googlebenchmark-src/src/benchmark.cc:496
#17 0x000000000024a989 in benchmark::RunSpecifiedBenchmarks () at ./build_gcc/_deps/googlebenchmark-src/src/benchmark.cc:437
#18 0x000000000023ebbe in main (argc=<optimized out>, argv=0x7ffec689d298) at ./utils/local-engine/tests/benchmark_local_engine.cpp:1581

```

Exception: 
```
Error while reading Parquet data: Invalid: Buffer #0 too small in array of type binary and length 600572: expected at least 75072 byte(s), got 1024: While executing ParquetBlockInputFormat

```


