### PR TITLE
improve the performance of converting row batch to column batch

### DIFF
--- a/utils/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -19,6 +19,7 @@ namespace local_engine
 jclass SparkRowToCHColumn::spark_row_interator_class = nullptr;
 jmethodID SparkRowToCHColumn::spark_row_interator_hasNext = nullptr;
 jmethodID SparkRowToCHColumn::spark_row_interator_next = nullptr;
+jmethodID SparkRowToCHColumn::spark_row_iterator_nextBuf = nullptr;
 
 int64_t getStringColumnTotalSize(int ordinal, SparkRowInfo & spark_row_info)
 {

--- a/utils/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -19,7 +19,7 @@ namespace local_engine
 jclass SparkRowToCHColumn::spark_row_interator_class = nullptr;
 jmethodID SparkRowToCHColumn::spark_row_interator_hasNext = nullptr;
 jmethodID SparkRowToCHColumn::spark_row_interator_next = nullptr;
-jmethodID SparkRowToCHColumn::spark_row_iterator_nextBuf = nullptr;
+jmethodID SparkRowToCHColumn::spark_row_iterator_nextBatch = nullptr;
 
 int64_t getStringColumnTotalSize(int ordinal, SparkRowInfo & spark_row_info)
 {

--- a/utils/local-engine/Parser/SparkRowToCHColumn.h
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.h
@@ -130,7 +130,7 @@ public:
     static jclass spark_row_interator_class;
     static jmethodID spark_row_interator_hasNext;
     static jmethodID spark_row_interator_next;
-    static jmethodID spark_row_iterator_nextBuf;
+    static jmethodID spark_row_iterator_nextBatch;
 
     // case 1: rows are batched (this is often directly converted from Block)
     static std::unique_ptr<Block> convertSparkRowInfoToCHColumn(SparkRowInfo & spark_row_info, Block & header);
@@ -144,7 +144,7 @@ public:
         JNIEnv * env = JNIUtils::getENV(&attached);
         while (env->CallBooleanMethod(java_iter, spark_row_interator_hasNext))
         {
-            jobject rows_buf = env->CallObjectMethod(java_iter, spark_row_iterator_nextBuf);
+            jobject rows_buf = env->CallObjectMethod(java_iter, spark_row_iterator_nextBatch);
             auto * rows_buf_ptr = static_cast<char*>(env->GetDirectBufferAddress(rows_buf));
             int len = *(reinterpret_cast<int*>(rows_buf_ptr));
 

--- a/utils/local-engine/Parser/SparkRowToCHColumn.h
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.h
@@ -156,6 +156,8 @@ public:
                 rows_buf_ptr += len;
                 len = *(reinterpret_cast<int*>(rows_buf_ptr));
             }
+            // Try to release reference.
+            env->DeleteLocalRef(rows_buf);
         }
         return getWrittenBlock(helper);
     }

--- a/utils/local-engine/Parser/SparkRowToCHColumn.h
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.h
@@ -130,6 +130,7 @@ public:
     static jclass spark_row_interator_class;
     static jmethodID spark_row_interator_hasNext;
     static jmethodID spark_row_interator_next;
+    static jmethodID spark_row_iterator_nextBuf;
 
     // case 1: rows are batched (this is often directly converted from Block)
     static std::unique_ptr<Block> convertSparkRowInfoToCHColumn(SparkRowInfo & spark_row_info, Block & header);
@@ -143,13 +144,18 @@ public:
         JNIEnv * env = JNIUtils::getENV(&attached);
         while (env->CallBooleanMethod(java_iter, spark_row_interator_hasNext))
         {
-            jbyteArray row_data = static_cast<jbyteArray>(env->CallObjectMethod(java_iter, spark_row_interator_next));
+            jobject rows_buf = env->CallObjectMethod(java_iter, spark_row_iterator_nextBuf);
+            auto * rows_buf_ptr = static_cast<char*>(env->GetDirectBufferAddress(rows_buf));
+            int len = *(reinterpret_cast<int*>(rows_buf_ptr));
 
-            jsize len = env->GetArrayLength(row_data);
-            char * c_arr = new char[len];
-            env->GetByteArrayRegion(row_data, 0, len, reinterpret_cast<jbyte*>(c_arr));
-            appendSparkRowToCHColumn(helper, reinterpret_cast<int64_t>(c_arr), len);
-            delete[] c_arr;
+            // when len = -1, reach the buf's end.
+            while (len > 0)
+            {
+                rows_buf_ptr += 4;
+                appendSparkRowToCHColumn(helper, reinterpret_cast<int64_t>(rows_buf_ptr), len);
+                rows_buf_ptr += len;
+                len = *(reinterpret_cast<int*>(rows_buf_ptr));
+            }
         }
         return getWrittenBlock(helper);
     }

--- a/utils/local-engine/local_engine_jni.cpp
+++ b/utils/local-engine/local_engine_jni.cpp
@@ -135,6 +135,8 @@ jint JNI_OnLoad(JavaVM * vm, void * /*reserved*/)
         = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "hasNext", "()Z");
     local_engine::SparkRowToCHColumn::spark_row_interator_next
         = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "next", "()[B");
+    local_engine::SparkRowToCHColumn::spark_row_iterator_nextBuf
+        = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "nextBuf", "()Ljava/nio/ByteBuffer;");
 
     local_engine::JNIUtils::vm = vm;
     return JNI_VERSION_1_8;

--- a/utils/local-engine/local_engine_jni.cpp
+++ b/utils/local-engine/local_engine_jni.cpp
@@ -135,8 +135,8 @@ jint JNI_OnLoad(JavaVM * vm, void * /*reserved*/)
         = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "hasNext", "()Z");
     local_engine::SparkRowToCHColumn::spark_row_interator_next
         = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "next", "()[B");
-    local_engine::SparkRowToCHColumn::spark_row_iterator_nextBuf
-        = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "nextBuf", "()Ljava/nio/ByteBuffer;");
+    local_engine::SparkRowToCHColumn::spark_row_iterator_nextBatch
+        = local_engine::GetMethodID(env, local_engine::SparkRowToCHColumn::spark_row_interator_class, "nextBatch", "()Ljava/nio/ByteBuffer;");
 
     local_engine::JNIUtils::vm = vm;
     return JNI_VERSION_1_8;


### PR DESCRIPTION
improve the performance of converting row to column by reducing jvm calls

Changelog category (leave one):
- Performance Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The overhead of java method call from jni is high. In converting a row batch into column batch, the total java call cost could reach almost halft of total time.

In this pr, we try to reduce the java calls from jni. `SparkRowIterator` has a new interface `nextBatch`, it will return a batch of rows instead of one row. And this make a significant improvement.

We run the following query (We disable the filter operator transform here).
```SQL
select count(msgtype) from (select appid + 1 as appid, msgtype,rtime  from test_table where msgtype = 14) as t;
```
use `SparkRowIterator.next` , time cost is
```
+-----------------+
| count(msgtype)  |
+-----------------+
| 16629906        |
+-----------------+
1 row selected (6.915 seconds)
```

with `SparkRowIterator.nextBatch`, time cost is
```
+-----------------+
| count(msgtype)  |
+-----------------+
| 16629906        |
+-----------------+
1 row selected (2.928 seconds)
```


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
