### PR TITLE
fixed a bug: coredump caused by transform a row batch with empty required columns into `DB::Block`

### DIFF
--- a/utils/local-engine/Parser/SparkRowToCHColumn.h
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.h
@@ -9,6 +9,7 @@
 #include <base/StringRef.h>
 #include <Common/JNIUtils.h>
 #include <jni/jni_common.h>
+#include "base/types.h"
 
 namespace local_engine
 {
@@ -41,6 +42,7 @@ struct SparkRowToCHColumnHelper
     unique_ptr<vector<MutableColumnPtr>> cols;
     unique_ptr<vector<DataTypePtr>> typePtrs;
     shared_ptr<Block> header;
+    UInt64 rows = 0;
 
     void resetWrittenColumns()
     {

--- a/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
+++ b/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
@@ -66,7 +66,7 @@ SubstraitFileSource::SubstraitFileSource(DB::ContextPtr context_, const DB::Bloc
 
 DB::Chunk SubstraitFileSource::generate()
 {
-    while(current_file_index < files.size())
+    while(true)
     {
         if (!tryPrepareReader())
         {

--- a/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
+++ b/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
@@ -81,6 +81,7 @@ DB::Chunk SubstraitFileSource::generate()
         /// try to read from next file
         file_reader.reset();
     }
+    return {};
 }
 
 bool SubstraitFileSource::tryPrepareReader()


### PR DESCRIPTION
the required columns could be empty in spark plan, and cause a coredump in SparkRowToCHColumn

Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

When there is no required columns in a row batch, we try to an anonymous const column in the result block of `SparkRowToCHColumn`. This could happend in some cases. E.g count(*)

This doesn't break the execution


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
