### PR TITLE
Support querying hive with hdfs as storage

### DIFF
--- a/utils/local-engine/Common/common.cpp
+++ b/utils/local-engine/Common/common.cpp
@@ -7,7 +7,12 @@
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Interpreters/JIT/CompiledExpressionCache.h>
 #include <Common/Logger.h>
+#include <Interpreters/Context_fwd.h>
 #include <jni.h>
+#include <Poco/Logger.h>
+#include <base/logger_useful.h>
+#include <filesystem>
+#include <Storages/HDFS/HDFSCommon.h>
 
 using namespace DB;
 #ifdef __cplusplus
@@ -20,6 +25,35 @@ void registerAllFunctions()
     registerAggregateFunctions();
 }
 
+/// If spark need to access hdfs, the environment variable `HADOOP_CONF_DIR` should have been set.
+/// For clickhosue, environment variable `LIBHDFS3_CONF` need to be set to initialize libhdfs3.
+/// So we use`HADOOP_CONF_DIR` from spark to setup `LIBHDFS3_CONF`.
+///
+/// TODO : Maybe initialize libhdfs3 by configure map but not a configure file path. Need to modify
+/// clickhouse.
+void setupHDFSConf(DB::Context::ConfigurationPtr context_config)
+{
+    const char * env_var = getenv("HADOOP_CONF_DIR");
+    if (env_var)
+    {
+        std::filesystem::path conf_dir(env_var);
+        auto conf_path = conf_dir / "hdfs-site.xml";
+        if (!std::filesystem::exists(conf_path))
+        {
+            LOG_WARNING(&Poco::Logger::get("local_engine"), "Not found hdfs configure file:{}", conf_path.string());
+        }
+        else
+        {
+            LOG_INFO(&Poco::Logger::get("local_engine"), "Setup hdfs.libhdfs3_conf by {}", conf_path.string());
+            context_config->setString("hdfs.libhdfs3_conf", conf_path.string());
+        }
+    }
+    else
+    {
+        LOG_INFO(&Poco::Logger::get("local_engine"), "HADOOP_CONF_DIR is not set, hdfs access may fail");
+    }
+
+}
 void init()
 {
     static std::once_flag init_flag;
@@ -48,6 +82,7 @@ void init()
                 = Context::createGlobal(local_engine::SerializedPlanParser::shared_context.get());
             local_engine::SerializedPlanParser::global_context->makeGlobalContext();
             local_engine::SerializedPlanParser::global_context->setSetting("join_use_nulls", true);
+            setupHDFSConf(local_engine::SerializedPlanParser::config);
             local_engine::SerializedPlanParser::global_context->setConfig(local_engine::SerializedPlanParser::config);
             local_engine::SerializedPlanParser::global_context->setPath("/");
         }

--- a/utils/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/utils/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -65,6 +65,11 @@ public:
         Poco::URI file_uri(file_info.uri_file());
         std::unique_ptr<DB::ReadBuffer> read_buffer;
         /// Need to set "hdfs.libhdfs3_conf" in global settings
+        if (context->getConfigRef().getString("hdfs.libhdfs3_conf", "").empty())
+        {
+            LOG_ERROR(&Poco::Logger::get("HDFSFileReadBufferBuilder"), "Not found configure hdfs.libhdfs3_conf");
+            throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "To use libhdfs3 to access hdfs, need to set hdfs.libhdfs3_conf in context configure");
+        }
         read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
             "hdfs://" + file_uri.getHost(), file_uri.getPath(), context->getGlobalContext()->getConfigRef());
         return read_buffer;

--- a/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
+++ b/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.cpp
@@ -19,9 +19,6 @@
 #include <Storages/SubstraitSource/FormatFile.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <substrait/plan.pb.h>
-
-#include <Poco/Logger.h>
-#include <base/logger_useful.h>
 #include <magic_enum.hpp>
 
 namespace DB

--- a/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.h
+++ b/utils/local-engine/Storages/SubstraitSource/SubstraitFileSource.h
@@ -14,6 +14,8 @@
 #include <DataTypes/Serializations/ISerialization.h>
 #include <Storages/SubstraitSource/ReadBufferBuilder.h>
 #include <QueryPipeline/QueryPipeline.h>
+#include <Poco/Logger.h>
+#include <base/logger_useful.h>
 namespace local_engine
 {
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

related to issue #145 .


libhdfs3 must be initialized by an hdfs-site.xml,  and the configure file path is refered by environment variable `LIBHDFS3_CONF`.

spark has the environment variable `HADOOP_CONF_DIR` to be set if it need to acccess hdfs files. So we use `HADOOP_CONF_DIR` to setup `LIBHDFS3_CONF` here.



> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
