### PR TITLE
[CH-170] Implement strings functions between spark and clickhouse: concat/instr/char_length/replace/abs/chr/ceil/floor/exp/power

### DIFF
--- a/utils/local-engine/Parser/SerializedPlanParser.cpp
+++ b/utils/local-engine/Parser/SerializedPlanParser.cpp
@@ -933,6 +933,16 @@ const ActionsDAG::Node * SerializedPlanParser::parseFunctionWithDAG(
         {
             required_columns.emplace_back(args[0]->result_name);
         }
+        else if (function_name == "splitByRegexp")
+        {
+            if (args.size() >= 2)
+            {
+                /// In Spark: split(str, regex [, limit] )
+                /// In CH: splitByRegexp(regexp, s)
+                std::swap(args[0], args[1]);
+            }
+        }
+
         if (function_signature.find("extract:", 0) != function_signature.npos)
         {
             // delete the first arg

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -41,11 +41,16 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"cast", ""},
     {"alias", "alias"},
 
+    /// arithmetic functions
     {"subtract", "minus"},
     {"multiply", "multiply"},
     {"add", "plus"},
     {"divide", "divide"},
     {"modulus", "modulo"},
+    {"abs", "abs"},
+    {"ceil", "ceil"},
+    {"floor", "floor"},
+    {"exp", "exp"},
 
     /// string functions
     {"like", "like"},
@@ -62,6 +67,8 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"strpos", "position"},
     {"char_length", "char_length"},
     {"replace", "replaceAll"},
+    {"chr", "char"},
+    {"power", "power"},
 
     // in functions
     {"in", "in"},

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -51,6 +51,7 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"ceil", "ceil"},
     {"floor", "floor"},
     {"exp", "exp"},
+    {"power", "power"},
 
     /// string functions
     {"like", "like"},
@@ -68,7 +69,6 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"char_length", "char_length"},
     {"replace", "replaceAll"},
     {"chr", "char"},
-    {"power", "power"},
 
     // in functions
     {"in", "in"},

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -61,6 +61,7 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"concat", "concat"},
     {"strpos", "position"},
     {"char_length", "char_length"},
+    {"replace", "replaceAll"},
 
     // in functions
     {"in", "in"},

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -58,6 +58,9 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"upper", "upper"},
     {"ltrim", "trimLeft"},
     {"rtrim", "trimRight"},
+    {"concat", "concat"},
+    {"strpos", "position"},
+    {"char_length", "char_length"},
 
     // in functions
     {"in", "in"},


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement strings functions between spark and clickhouse: ascii/concat/instr/char_length/replace/split, which close https://github.com/Kyligence/ClickHouse/issues/170

- [x] concat
- [x] instr
- [x] char_length
- [ ] ascii
- [x] replace
- [ ] split
- [x] abs/chr/ceil/floor/exp/power
- [ ] pmod



### concat 
```
0: jdbc:hive2://localhost:10000/> explain formatted select concat(l_shipinstruct, l_shipmode) from lineitem limit 10; 
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (5)
+- CHNativeColumnarToRow (4)
   +- * ProjectExecTransformer (2)
      +- * Scan parquet  (1)


(1) Scan parquet 
Output [2]: [l_shipinstruct#162, l_shipmode#163]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
ReadSchema: struct<l_shipinstruct:string,l_shipmode:string>

(2) ProjectExecTransformer
Input [2]: [l_shipinstruct#162, l_shipmode#163]
Arguments: [concat(l_shipinstruct#162, l_shipmode#163) AS concat(l_shipinstruct, l_shipmode)#217]

(3) WholeStageCodegenTransformer (5)
Input [1]: [concat(l_shipinstruct, l_shipmode)#217]

(4) CHNativeColumnarToRow
Input [1]: [concat(l_shipinstruct, l_shipmode)#217]

(5) CollectLimit
Input [1]: [concat(l_shipinstruct, l_shipmode)#217]
Arguments: 10
```

### instr
```
0: jdbc:hive2://localhost:10000/> explain formatted select instr(l_shipinstruct, 'A') from lineitem limit 10; 
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (5)
+- CHNativeColumnarToRow (4)
   +- * ProjectExecTransformer (2)
      +- * Scan parquet  (1)


(1) Scan parquet 
Output [1]: [l_shipinstruct#162]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
ReadSchema: struct<l_shipinstruct:string>

(2) ProjectExecTransformer
Input [1]: [l_shipinstruct#162]
Arguments: [instr(l_shipinstruct#162, A) AS instr(l_shipinstruct, A)#225]

(3) WholeStageCodegenTransformer (6)
Input [1]: [instr(l_shipinstruct, A)#225]

(4) CHNativeColumnarToRow
Input [1]: [instr(l_shipinstruct, A)#225]

(5) CollectLimit
Input [1]: [instr(l_shipinstruct, A)#225]
Arguments: 10 
```


### char_length
```
0: jdbc:hive2://localhost:10000/> explain formatted select char_length(l_shipinstruct) from lineitem limit 10; 
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (5)
+- CHNativeColumnarToRow (4)
   +- * ProjectExecTransformer (2)
      +- * Scan parquet  (1)


(1) Scan parquet 
Output [1]: [l_shipinstruct#162]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
ReadSchema: struct<l_shipinstruct:string>

(2) ProjectExecTransformer
Input [1]: [l_shipinstruct#162]
Arguments: [char_length(l_shipinstruct#162) AS char_length(l_shipinstruct)#260]

(3) WholeStageCodegenTransformer (12)
Input [1]: [char_length(l_shipinstruct)#260]

(4) CHNativeColumnarToRow
Input [1]: [char_length(l_shipinstruct)#260]

(5) CollectLimit
Input [1]: [char_length(l_shipinstruct)#260]
Arguments: 10
```


### ascii
```
0: jdbc:hive2://localhost:10000/> explain formatted select ascii(l_shipinstruct) from lineitem limit 10; 
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (5)
+- CHNativeColumnarToRow (4)
   +- * ProjectExecTransformer (2)
      +- * Scan parquet  (1)


(1) Scan parquet 
Output [1]: [l_shipinstruct#13]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
ReadSchema: struct<l_shipinstruct:string>

(2) ProjectExecTransformer
Input [1]: [l_shipinstruct#13]
Arguments: [ascii(l_shipinstruct#13) AS ascii(l_shipinstruct)#52]

(3) WholeStageCodegenTransformer (2)
Input [1]: [ascii(l_shipinstruct)#52]

(4) CHNativeColumnarToRow
Input [1]: [ascii(l_shipinstruct)#52]

(5) CollectLimit
Input [1]: [ascii(l_shipinstruct)#52]
Arguments: 10
```

### replace 
```
0: jdbc:hive2://localhost:10000/> explain formatted select  replace(l_comment, 'the', 'that')  from lineitem limit 10 ; 
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Physical Plan ==
CollectLimit (5)
+- CHNativeColumnarToRow (4)
   +- * ProjectExecTransformer (2)
      +- * Scan parquet  (1)


(1) Scan parquet 
Output [1]: [l_comment#15]
Batched: true
Location: InMemoryFileIndex [file:/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem]
ReadSchema: struct<l_comment:string>

(2) ProjectExecTransformer
Input [1]: [l_comment#15]
Arguments: [replace(l_comment#15, the, that) AS replace(l_comment, the, that)#55]

(3) WholeStageCodegenTransformer (3)
Input [1]: [replace(l_comment, the, that)#55]

(4) CHNativeColumnarToRow
Input [1]: [replace(l_comment, the, that)#55]

(5) CollectLimit
Input [1]: [replace(l_comment, the, that)#55]
Arguments: 10


```