### PR TITLE
[CH-45]support count(*/count(1)

### DIFF
--- a/utils/local-engine/Common/CHUtil.cpp
+++ b/utils/local-engine/Common/CHUtil.cpp
@@ -19,7 +19,7 @@ namespace ErrorCodes
 }
 namespace local_engine
 {
-constexpr auto VIRTUAL_ROW_COUNT_COL = "__virtual_row_count_col__";
+constexpr auto VIRTUAL_ROW_COUNT_COLOUMN = "__VIRTUAL_ROW_COUNT_COLOUMNOUMN__";
 
 namespace fs = std::filesystem;
 
@@ -28,7 +28,7 @@ DB::Block BlockUtil::buildRowCountHeader()
     DB::Block header;
     auto uint8_ty = std::make_shared<DB::DataTypeUInt8>();
     auto col = uint8_ty->createColumn();
-    DB::ColumnWithTypeAndName named_col(std::move(col), uint8_ty, VIRTUAL_ROW_COUNT_COL);
+    DB::ColumnWithTypeAndName named_col(std::move(col), uint8_ty, VIRTUAL_ROW_COUNT_COLOUMN);
     header.insert(named_col);
     return header.cloneEmpty();
 }
@@ -47,7 +47,7 @@ DB::Block BlockUtil::buildRowCountBlock(UInt64 rows)
     DB::Block block;
     auto uint8_ty = std::make_shared<DB::DataTypeUInt8>();
     auto col = uint8_ty->createColumnConst(rows, 0);
-    DB::ColumnWithTypeAndName named_col(col, uint8_ty, VIRTUAL_ROW_COUNT_COL);
+    DB::ColumnWithTypeAndName named_col(col, uint8_ty, VIRTUAL_ROW_COUNT_COLOUMN);
     block.insert(named_col);
     return block;
 }
@@ -93,7 +93,7 @@ std::vector<MergeTreeUtil::Path> MergeTreeUtil::getAllMergeTreeParts(const Path 
     return res;
 }
 
-DB::NamesAndTypesList MergeTreeUtil::getSchemaFromMergeTreePartFiles(const fs::path & part_path)
+DB::NamesAndTypesList MergeTreeUtil::getSchemaFromMergeTreePart(const fs::path & part_path)
 {
     DB::NamesAndTypesList names_types_list;
     if (!fs::exists(part_path))

--- a/utils/local-engine/Common/CHUtil.cpp
+++ b/utils/local-engine/Common/CHUtil.cpp
@@ -1,0 +1,108 @@
+#include <filesystem>
+#include <Common/CHUtil.h>
+#include <Core/Block.h>
+#include <Core/ColumnWithTypeAndName.h>
+#include <Core/NamesAndTypes.h>
+#include <IO/ReadBufferFromFile.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <Processors/Chunk.h>
+#include <Processors/QueryPlan/QueryPlan.h>
+#include <Core/ColumnsWithTypeAndName.h>
+#include <DataTypes/DataTypesNumber.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+}
+namespace local_engine
+{
+constexpr auto VIRTUAL_ROW_COUNT_COL = "__virtual_row_count_col__";
+
+namespace fs = std::filesystem;
+
+DB::Block BlockUtil::buildRowCountHeader()
+{
+    DB::Block header;
+    auto uint8_ty = std::make_shared<DB::DataTypeUInt8>();
+    auto col = uint8_ty->createColumn();
+    DB::ColumnWithTypeAndName named_col(std::move(col), uint8_ty, VIRTUAL_ROW_COUNT_COL);
+    header.insert(named_col);
+    return header.cloneEmpty();
+}
+
+DB::Chunk BlockUtil::buildRowCountChunk(UInt64 rows)
+{
+    auto data_type = std::make_shared<DB::DataTypeUInt8>();
+    auto col = data_type->createColumnConst(rows, 0);
+    DB::Columns res_columns;
+    res_columns.emplace_back(std::move(col));
+    return DB::Chunk(std::move(res_columns), rows);
+}
+
+DB::Block BlockUtil::buildRowCountBlock(UInt64 rows)
+{
+    DB::Block block;
+    auto uint8_ty = std::make_shared<DB::DataTypeUInt8>();
+    auto col = uint8_ty->createColumnConst(rows, 0);
+    DB::ColumnWithTypeAndName named_col(col, uint8_ty, VIRTUAL_ROW_COUNT_COL);
+    block.insert(named_col);
+    return block;
+}
+
+DB::Block BlockUtil::buildHeader(const DB::NamesAndTypesList & names_types_list)
+{
+    DB::ColumnsWithTypeAndName cols;
+    for (const auto & name_type : names_types_list)
+    {
+        DB::ColumnWithTypeAndName col(name_type.type->createColumn(), name_type.type, name_type.name);
+        cols.emplace_back(col);
+    }
+    return DB::Block(cols);
+}
+
+
+std::string PlanUtil::explainPlan(DB::QueryPlan & plan)
+{
+    std::string plan_str;
+    DB::QueryPlan::ExplainPlanOptions buf_opt;
+    DB::WriteBufferFromOwnString buf;
+    plan.explainPlan(buf, buf_opt);
+    plan_str = buf.str();
+    return plan_str;
+}
+
+std::vector<MergeTreeUtil::Path> MergeTreeUtil::getAllMergeTreeParts(const Path &storage_path)
+{
+    if (!fs::exists(storage_path))
+    {
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid merge tree store path:{}", storage_path.string());
+    }
+
+    // TODO: May need to check the storage format version
+    std::vector<fs::path> res;
+    for (const auto & entry : fs::directory_iterator(storage_path))
+    {
+        auto filename = entry.path().filename();
+        if (filename == "format_version.txt" || filename == "detached")
+            continue;
+        res.push_back(entry.path());
+    }
+    return res;
+}
+
+DB::NamesAndTypesList MergeTreeUtil::getSchemaFromMergeTreePartFiles(const fs::path & part_path)
+{
+    DB::NamesAndTypesList names_types_list;
+    if (!fs::exists(part_path))
+    {
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Invalid merge tree store path:{}", part_path.string());
+    }
+    DB::ReadBufferFromFile readbuffer((part_path / "columns.txt").string());
+    names_types_list.readText(readbuffer);
+    return names_types_list;
+}
+
+}

--- a/utils/local-engine/Common/CHUtil.h
+++ b/utils/local-engine/Common/CHUtil.h
@@ -35,7 +35,7 @@ class MergeTreeUtil
 public:
     using Path = std::filesystem::path;
     static std::vector<Path> getAllMergeTreeParts(const Path & storage_path);
-    static DB::NamesAndTypesList getSchemaFromMergeTreePartFiles(const Path & part_path);
+    static DB::NamesAndTypesList getSchemaFromMergeTreePart(const Path & part_path);
 };
 
 }

--- a/utils/local-engine/Common/CHUtil.h
+++ b/utils/local-engine/Common/CHUtil.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <Core/Block.h>
+#include <Processors/Chunk.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <base/types.h>
+#include <Storages/IStorage.h>
+#include <Core/NamesAndTypes.h>
+#include <filesystem>
+namespace local_engine
+{
+
+class BlockUtil
+{
+public:
+    // Build a header block with a virtual column which will be
+    // use to indicate the number of rows in a block.
+    // Commonly seen in the following quries:
+    // - select count(1) from t
+    // - select 1 from t
+    static DB::Block buildRowCountHeader();
+    static DB::Chunk buildRowCountChunk(UInt64 rows);
+    static DB::Block buildRowCountBlock(UInt64 rows);
+
+    static DB::Block buildHeader(const DB::NamesAndTypesList & names_types_list);
+};
+
+class PlanUtil
+{
+public:
+    static std::string explainPlan(DB::QueryPlan & plan);
+};
+
+class MergeTreeUtil
+{
+public:
+    using Path = std::filesystem::path;
+    static std::vector<Path> getAllMergeTreeParts(const Path & storage_path);
+    static DB::NamesAndTypesList getSchemaFromMergeTreePartFiles(const Path & part_path);
+};
+
+}

--- a/utils/local-engine/Parser/SerializedPlanParser.cpp
+++ b/utils/local-engine/Parser/SerializedPlanParser.cpp
@@ -251,7 +251,7 @@ QueryPlanPtr SerializedPlanParser::parseMergeTreeTable(const substrait::ReadRel 
         {
             throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Empty mergetree directory: {}", merge_tree_table.relative_path);
         }
-        auto part_names_types_list = MergeTreeUtil::getSchemaFromMergeTreePartFiles(all_parts_dir[0]);
+        auto part_names_types_list = MergeTreeUtil::getSchemaFromMergeTreePart(all_parts_dir[0]);
         NamesAndTypesList one_column_name_type;
         one_column_name_type.push_back(part_names_types_list.front());
         header = BlockUtil::buildHeader(one_column_name_type);

--- a/utils/local-engine/Parser/SerializedPlanParser.cpp
+++ b/utils/local-engine/Parser/SerializedPlanParser.cpp
@@ -48,6 +48,7 @@
 #include <Processors/QueryPlan/SortingStep.h>
 #include "SerializedPlanParser.h"
 #include <Storages/IStorage.h>
+#include <Common/CHUtil.h>
 
 namespace DB
 {
@@ -235,10 +236,27 @@ QueryPlanPtr SerializedPlanParser::parseMergeTreeTable(const substrait::ReadRel 
     Stopwatch watch;
     watch.start();
     assert(rel.has_extension_table());
-    assert(rel.has_base_schema());
     std::string table = rel.extension_table().detail().value();
     auto merge_tree_table = local_engine::parseMergeTreeTableString(table);
-    auto header = parseNameStruct(rel.base_schema());
+    DB::Block header;
+    if (rel.has_base_schema() && rel.base_schema().names_size())
+    {
+        header = parseNameStruct(rel.base_schema());
+    }
+    else
+    {
+        // For count(*) case, there will be an empty base_schema, so we try to read at least once column
+        auto all_parts_dir = MergeTreeUtil::getAllMergeTreeParts( std::filesystem::path("/") / merge_tree_table.relative_path);
+        if (all_parts_dir.empty())
+        {
+            throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Empty mergetree directory: {}", merge_tree_table.relative_path);
+        }
+        auto part_names_types_list = MergeTreeUtil::getSchemaFromMergeTreePartFiles(all_parts_dir[0]);
+        NamesAndTypesList one_column_name_type;
+        one_column_name_type.push_back(part_names_types_list.front());
+        header = BlockUtil::buildHeader(one_column_name_type);
+        LOG_DEBUG(&Poco::Logger::get("SerializedPlanParser"), "Try to read ({}) instead of empty header", header.dumpNames());
+    }
     auto names_and_types_list = header.getNamesAndTypesList();
     auto storage_factory = StorageMergeTreeFactory::instance();
     auto metadata = buildMetaData(names_and_types_list, this->context);
@@ -417,17 +435,20 @@ QueryPlanPtr SerializedPlanParser::parse(std::unique_ptr<substrait::Plan> plan)
         }
 
         auto query_plan = parseOp(root_rel.root().input());
-        ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(blockToNameAndTypeList(query_plan->getCurrentDataStream().header));
-        NamesWithAliases aliases;
-        auto cols = query_plan->getCurrentDataStream().header.getNamesAndTypesList();
-        for (int i = 0; i < root_rel.root().names_size(); i++)
+        if (root_rel.root().names_size())
         {
-            aliases.emplace_back(NameWithAlias(cols.getNames()[i], root_rel.root().names(i)));
+            ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(blockToNameAndTypeList(query_plan->getCurrentDataStream().header));
+            NamesWithAliases aliases;
+            auto cols = query_plan->getCurrentDataStream().header.getNamesAndTypesList();
+            for (int i = 0; i < root_rel.root().names_size(); i++)
+            {
+                aliases.emplace_back(NameWithAlias(cols.getNames()[i], root_rel.root().names(i)));
+            }
+            actions_dag->project(aliases);
+            auto expression_step = std::make_unique<ExpressionStep>(query_plan->getCurrentDataStream(), actions_dag);
+            expression_step->setStepDescription("Rename Output");
+            query_plan->addStep(std::move(expression_step));
         }
-        actions_dag->project(aliases);
-        auto expression_step = std::make_unique<ExpressionStep>(query_plan->getCurrentDataStream(), actions_dag);
-        expression_step->setStepDescription("Rename Output");
-        query_plan->addStep(std::move(expression_step));
 
         if (logger->trace())
         {
@@ -1661,10 +1682,11 @@ SharedContextHolder SerializedPlanParser::shared_context;
 
 void LocalExecutor::execute(QueryPlanPtr query_plan)
 {
+    current_query_plan = std::move(query_plan);
     Stopwatch stopwatch;
     stopwatch.start();
     QueryPlanOptimizationSettings optimization_settings{.optimize_plan = true};
-    auto pipeline_builder = query_plan->buildQueryPipeline(
+    auto pipeline_builder = current_query_plan->buildQueryPipeline(
         optimization_settings,
         BuildQueryPipelineSettings{
             .actions_settings = ExpressionActionsSettings{
@@ -1679,7 +1701,7 @@ void LocalExecutor::execute(QueryPlanPtr query_plan)
         "build pipeline {} ms; create executor {} ms;",
         t_pipeline / 1000.0,
         t_executor / 1000.0);
-    this->header = query_plan->getCurrentDataStream().header.cloneEmpty();
+    this->header = current_query_plan->getCurrentDataStream().header.cloneEmpty();
     this->ch_column_to_spark_row = std::make_unique<CHColumnToSparkRow>();
 }
 std::unique_ptr<SparkRowInfo> LocalExecutor::writeBlockToSparkRow(Block & block)
@@ -1689,16 +1711,25 @@ std::unique_ptr<SparkRowInfo> LocalExecutor::writeBlockToSparkRow(Block & block)
 bool LocalExecutor::hasNext()
 {
     bool has_next;
-    if (currentBlock().columns() == 0 || isConsumed())
+    try
     {
-        auto empty_block = header.cloneEmpty();
-        setCurrentBlock(empty_block);
-        has_next = this->executor->pull(currentBlock());
-        produce();
+        if (currentBlock().columns() == 0 || isConsumed())
+        {
+            auto empty_block = header.cloneEmpty();
+            setCurrentBlock(empty_block);
+            has_next = this->executor->pull(currentBlock());
+            produce();
+        }
+        else
+        {
+            has_next = true;
+        }
     }
-    else
+    catch (DB::Exception & e)
     {
-        has_next = true;
+        LOG_ERROR(
+            &Poco::Logger::get("LocalExecutor"), "run query plan failed. {}\n{}", e.message(), PlanUtil::explainPlan(*current_query_plan));
+        throw e;
     }
     return has_next;
 }
@@ -1740,7 +1771,8 @@ Block & LocalExecutor::getHeader()
 {
     return header;
 }
-LocalExecutor::LocalExecutor(QueryContext & _query_context) : query_context(_query_context)
+LocalExecutor::LocalExecutor(QueryContext & _query_context)
+    : query_context(_query_context)
 {
 }
 }

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -90,8 +90,6 @@ public:
     DB::QueryPlanPtr parseReadRealWithLocalFile(const substrait::ReadRel & rel);
     DB::QueryPlanPtr parseReadRealWithJavaIter(const substrait::ReadRel & rel);
     DB::QueryPlanPtr parseMergeTreeTable(const substrait::ReadRel & rel);
-    DB::Block parseSchemeFromMergeTreeFile(const std::string & path);
-
 
     static bool isReadRelFromJava(const substrait::ReadRel & rel);
     static DB::Block parseNameStruct(const substrait::NamedStruct & struct_);

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -17,7 +17,7 @@
 #include <arrow/ipc/writer.h>
 #include <substrait/plan.pb.h>
 #include <Common/BlockIterator.h>
-#include "Core/SortDescription.h"
+#include <Core/SortDescription.h>
 
 namespace local_engine
 {
@@ -90,6 +90,8 @@ public:
     DB::QueryPlanPtr parseReadRealWithLocalFile(const substrait::ReadRel & rel);
     DB::QueryPlanPtr parseReadRealWithJavaIter(const substrait::ReadRel & rel);
     DB::QueryPlanPtr parseMergeTreeTable(const substrait::ReadRel & rel);
+    DB::Block parseSchemeFromMergeTreeFile(const std::string & path);
+
 
     static bool isReadRelFromJava(const substrait::ReadRel & rel);
     static DB::Block parseNameStruct(const substrait::NamedStruct & struct_);
@@ -204,5 +206,6 @@ private:
     Block header;
     std::unique_ptr<CHColumnToSparkRow> ch_column_to_spark_row;
     std::unique_ptr<SparkBuffer> spark_buffer;
+    DB::QueryPlanPtr current_query_plan;
 };
 }

--- a/utils/local-engine/Storages/SourceFromJavaIter.cpp
+++ b/utils/local-engine/Storages/SourceFromJavaIter.cpp
@@ -1,9 +1,22 @@
 #include "SourceFromJavaIter.h"
 #include <Columns/ColumnNullable.h>
 #include <Processors/Transforms/AggregatingTransform.h>
-#include <jni/jni_common.h>
+#include <Common/Exception.h>
 #include <Common/DebugUtils.h>
 #include <Common/JNIUtils.h>
+#include <Columns/ColumnNullable.h>
+#include <jni/jni_common.h>
+#include <Core/ColumnsWithTypeAndName.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Common/CHUtil.h>
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+}
 
 namespace local_engine
 {
@@ -11,6 +24,19 @@ jclass SourceFromJavaIter::serialized_record_batch_iterator_class = nullptr;
 jmethodID SourceFromJavaIter::serialized_record_batch_iterator_hasNext = nullptr;
 jmethodID SourceFromJavaIter::serialized_record_batch_iterator_next = nullptr;
 
+
+static DB::Block getRealHeader(const DB::Block & header)
+{
+    if (header.columns())
+        return header;
+    return BlockUtil::buildRowCountHeader();
+}
+SourceFromJavaIter::SourceFromJavaIter(DB::Block header, jobject java_iter_)
+    : DB::ISource(getRealHeader(header))
+    , java_iter(java_iter_)
+    , original_header(header)
+{
+}
 DB::Chunk SourceFromJavaIter::generate()
 {
     GET_JNIENV(env)
@@ -23,12 +49,19 @@ DB::Chunk SourceFromJavaIter::generate()
         if (data->rows() > 0)
         {
             size_t rows = data->rows();
-            result.setColumns(data->mutateColumns(), rows);
-            convertNullable(result);
-            auto info = std::make_shared<DB::AggregatedChunkInfo>();
-            info->is_overflows = data->info.is_overflows;
-            info->bucket_num = data->info.bucket_num;
-            result.setChunkInfo(info);
+            if (original_header.columns())
+            {
+                result.setColumns(data->mutateColumns(), rows);
+                convertNullable(result);
+                auto info = std::make_shared<DB::AggregatedChunkInfo>();
+                info->is_overflows = data->info.is_overflows;
+                info->bucket_num = data->info.bucket_num;
+                result.setChunkInfo(info);
+            }
+            else
+            {
+                result = BlockUtil::buildRowCountChunk(rows);
+            }
         }
     }
     CLEAN_JNIENV
@@ -53,9 +86,9 @@ Int64 SourceFromJavaIter::byteArrayToLong(JNIEnv * env, jbyteArray arr)
 }
 void SourceFromJavaIter::convertNullable(DB::Chunk & chunk)
 {
+    auto output = this->getOutputs().front().getHeader();
     auto rows = chunk.getNumRows();
     auto columns = chunk.detachColumns();
-    auto output = this->getOutputs().front().getHeader();
     for (size_t i = 0; i < columns.size(); ++i)
     {
         DB::WhichDataType which(columns.at(i)->getDataType());

--- a/utils/local-engine/Storages/SourceFromJavaIter.cpp
+++ b/utils/local-engine/Storages/SourceFromJavaIter.cpp
@@ -10,14 +10,6 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Common/CHUtil.h>
 
-namespace DB
-{
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
-}
-
 namespace local_engine
 {
 jclass SourceFromJavaIter::serialized_record_batch_iterator_class = nullptr;

--- a/utils/local-engine/Storages/SourceFromJavaIter.h
+++ b/utils/local-engine/Storages/SourceFromJavaIter.h
@@ -13,7 +13,7 @@ public:
 
     static Int64 byteArrayToLong(JNIEnv * env, jbyteArray arr);
 
-    SourceFromJavaIter(DB::Block header, jobject java_iter_) : DB::ISource(header), java_iter(java_iter_) { }
+    SourceFromJavaIter(DB::Block header, jobject java_iter_);
     ~SourceFromJavaIter() override;
 
     String getName() const override { return "SourceFromJavaIter"; }
@@ -23,6 +23,7 @@ private:
     void convertNullable(DB::Chunk & chunk);
 
     jobject java_iter;
+    DB::Block original_header;
 };
 
 }


### PR DESCRIPTION
support count(*)/count(1)

Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
relate to issue https://github.com/Kyligence/ClickHouse/issues/45

Read from file sources or java batch iterator will fail with empty columns to read. This happends when running the following queries.
```SQL
select count(1) from t;
select sum(1) from t;
select 1 from t;
```
In this case, the rows number is the only information to need. To solve this, we try to build a block with an virtual column which indicates the rows number, and this virtual column will not be really used.


In `SubstraitFileSource`, if the file implement `getTotalRows`, we build blocks with a constant column whose total size is equal to `getTotalRows`'s result.

In `SourceFromJavaIter`, we also return  blocks with a constant column whose size is equal to input block's rows.

For merge tree, we try to read a least one column instead of the original empty header.




> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
