### PR TITLE
[CH-180] Support non-HA mode for ClickHouse reading from HDFS

### DIFF
--- a/utils/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/utils/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -69,8 +69,11 @@ public:
         {
             throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Not found hdfs.libhdfs3_conf");
         }
+        std::string uriPath = "hdfs://" + file_uri.getHost();
+        if (file_uri.getPort())
+            uriPath += ":" + std::to_string(file_uri.getPort());
         read_buffer = std::make_unique<DB::ReadBufferFromHDFS>(
-            "hdfs://" + file_uri.getHost(), file_uri.getPath(), context->getGlobalContext()->getConfigRef());
+            uriPath, file_uri.getPath(), context->getGlobalContext()->getConfigRef());
         return read_buffer;
     }
 };


### PR DESCRIPTION
Support non-HA mode for ClickHouse reading from HDFS.

Close #180 .

Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehaviour in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
