### PR TITLE
[CH-206] Add format settings for parsing parquet files

### DIFF
--- a/utils/local-engine/Storages/ArrowParquetBlockInputFormat.cpp
+++ b/utils/local-engine/Storages/ArrowParquetBlockInputFormat.cpp
@@ -51,30 +51,6 @@ DB::Chunk ArrowParquetBlockInputFormat::generate()
     {
         prepareReader();
         file_reader->set_batch_size(8192);
-        std::shared_ptr<::arrow::Schema> schema;
-        file_reader->GetSchema(&schema);
-//        file_reader->set_use_threads(true);
-        std::unordered_set<String> nested_table_names;
-        if (format_settings.parquet.import_nested)
-            nested_table_names = Nested::getAllTableNames(getPort().getHeader());
-        int index = 0;
-        for (int i = 0; i < schema->num_fields(); ++i)
-        {
-            /// STRUCT type require the number of indexes equal to the number of
-            /// nested elements, so we should recursively
-            /// count the number of indices we need for this type.
-            int indexes_count = countIndicesForType(schema->field(i)->type());
-            const auto & name = schema->field(i)->name();
-            if (getPort().getHeader().has(name) || nested_table_names.contains(name))
-            {
-                for (int j = 0; j != indexes_count; ++j)
-                {
-                    column_indices.push_back(index + j);
-                    column_names.push_back(name);
-                }
-            }
-            index += indexes_count;
-        }
         if (row_group_indices.empty())
         {
             auto row_group_range = boost::irange(0, file_reader->num_row_groups());
@@ -95,6 +71,10 @@ DB::Chunk ArrowParquetBlockInputFormat::generate()
     if (*batch)
     {
         auto tmp_table = arrow::Table::FromRecordBatches({*batch});
+        if (format_settings.use_lowercase_column_name)
+        {
+            tmp_table = (*tmp_table)->RenameColumns(column_names);
+        }
         non_convert_time += watch.elapsedNanoseconds();
         watch.restart();
         arrow_column_to_ch_column->arrowTableToCHChunk(res, *tmp_table);

--- a/utils/local-engine/Storages/SubstraitSource/ParquetFormatFile.cpp
+++ b/utils/local-engine/Storages/SubstraitSource/ParquetFormatFile.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <Formats/FormatFactory.h>
 #include <Formats/FormatSettings.h>
 #include <Processors/Formats/Impl/ArrowBufferedStreams.h>
 #include <Storages/ArrowParquetBlockInputFormat.h>
@@ -25,7 +26,8 @@ FormatFile::InputFormatPtr ParquetFormatFile::createInputFormat(const DB::Block 
 {
     auto row_group_indices = collectRowGroupIndices();
     auto read_buffer = read_buffer_builder->build(file_info);
-    auto input_format = std::make_shared<local_engine::ArrowParquetBlockInputFormat>(*read_buffer, header, DB::FormatSettings(), row_group_indices);
+    auto format_settings = DB::getFormatSettings(context);
+    auto input_format = std::make_shared<local_engine::ArrowParquetBlockInputFormat>(*read_buffer, header, format_settings, row_group_indices);
     auto res = std::make_shared<FormatFile::InputFormat>(input_format, std::move(read_buffer));
     return res;
 }


### PR DESCRIPTION
Changelog category (leave one):

- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

add format settings for parsing parquet files.

enable `use_lowercase_column_name` in parsing parquet files.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
