### PR TITLE
Fixed a bug which may cause coredump

### DIFF
--- a/utils/local-engine/Shuffle/NativeSplitter.cpp
+++ b/utils/local-engine/Shuffle/NativeSplitter.cpp
@@ -23,6 +23,16 @@ jmethodID NativeSplitter::iterator_next = nullptr;
 
 void NativeSplitter::split(DB::Block & block)
 {
+    if (!block.rows())
+    {
+        for (size_t i = 0; i < options.partition_nums; ++i)
+        {
+            auto new_block = std::make_unique<Block>();
+            *new_block = block;
+            output_buffer.emplace(std::pair(i, std::move(new_block)));
+        }
+        return;
+    }
     computePartitionId(block);
     DB::IColumn::Selector selector;
     selector = DB::IColumn::Selector(block.rows());

--- a/utils/local-engine/Shuffle/SelectorBuilder.h
+++ b/utils/local-engine/Shuffle/SelectorBuilder.h
@@ -1,16 +1,17 @@
 #pragma once
-#include <Core/ColumnWithTypeAndName.h>
-#include <Functions/IFunction.h>
-#include <Processors/Chunk.h>
-#include <base/types.h>
-#include <Core/SortDescription.h>
-#include <Core/Block.h>
-#include <Common/BlockIterator.h>
 #include <memory>
 #include <vector>
-#include <substrait/plan.pb.h>
+#include <Core/Block.h>
+#include <Core/ColumnWithTypeAndName.h>
+#include <Core/SortDescription.h>
+#include <Functions/IFunction.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Parser/SerializedPlanParser.h>
+#include <Processors/Chunk.h>
+#include <base/types.h>
+#include <substrait/plan.pb.h>
+#include <Common/BlockIterator.h>
 namespace local_engine
 {
 class RoundRobinSelectorBuilder
@@ -55,6 +56,7 @@ private:
     std::mutex actions_dag_mutex;
     std::unique_ptr<substrait::Plan> projection_plan_pb;
     std::atomic<bool> has_init_actions_dag;
+    std::unique_ptr<SerializedPlanParser> plan_parser;
     std::unique_ptr<DB::ExpressionActions> projection_expression_actions;
 
     void initSortInformation(Poco::JSON::Array::Ptr orderings);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)



Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The row argument is required to be a reference, we cannot pass a right value variable here


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
