### PR TITLE
Fix decimal bug cased by big-endian encoding in spark row.

### DIFF
--- a/utils/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -107,14 +107,31 @@ static void writeVariableLengthNonNullableValue(
 {
     const auto type_without_nullable{std::move(removeNullable(col.type))};
     const bool use_raw_data = BackingDataLengthCalculator::isDataTypeSupportRawData(type_without_nullable);
+    const bool big_endian = BackingDataLengthCalculator::isBigEndianInSparkRow(type_without_nullable);
     VariableLengthDataWriter writer(col.type, buffer_address, offsets, buffer_cursor);
     if (use_raw_data)
     {
-        for (size_t i = 0; i < static_cast<size_t>(num_rows); i++)
+        if (!big_endian)
         {
-            StringRef str = col.column->getDataAt(i);
-            int64_t offset_and_size = writer.writeUnalignedBytes(i, str.data, str.size, 0);
-            memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
+            for (size_t i = 0; i < static_cast<size_t>(num_rows); i++)
+            {
+                StringRef str = col.column->getDataAt(i);
+                int64_t offset_and_size = writer.writeUnalignedBytes(i, str.data, str.size, 0);
+                memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
+            }
+        }
+        else
+        {
+            Field field;
+            for (size_t i = 0; i < static_cast<size_t>(num_rows); i++)
+            {
+                StringRef str_view = col.column->getDataAt(i);
+                String buf(str_view.data, str_view.size);
+                auto * decimal128 = reinterpret_cast<Decimal128 *>(buf.data());
+                BackingDataLengthCalculator::swapBytes(*decimal128);
+                int64_t offset_and_size = writer.writeUnalignedBytes(i, buf.data(), buf.size(), 0);
+                memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
+            }
         }
     }
     else
@@ -143,6 +160,7 @@ static void writeVariableLengthNullableValue(
     const auto & nested_column = nullable_column->getNestedColumn();
     const auto type_without_nullable{std::move(removeNullable(col.type))};
     const bool use_raw_data = BackingDataLengthCalculator::isDataTypeSupportRawData(type_without_nullable);
+    const bool big_endian = BackingDataLengthCalculator::isBigEndianInSparkRow(type_without_nullable);
     VariableLengthDataWriter writer(col.type, buffer_address, offsets, buffer_cursor);
     if (use_raw_data)
     {
@@ -150,10 +168,19 @@ static void writeVariableLengthNullableValue(
         {
             if (null_map[i])
                 bitSet(buffer_address + offsets[i], col_index);
-            else
+            else if (!big_endian)
             {
                 StringRef str = nested_column.getDataAt(i);
                 int64_t offset_and_size = writer.writeUnalignedBytes(i, str.data, str.size, 0);
+                memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
+            }
+            else
+            {
+                StringRef str_view = nested_column.getDataAt(i);
+                String buf(str_view.data, str_view.size);
+                auto * decimal128 = reinterpret_cast<Decimal128 *>(buf.data());
+                BackingDataLengthCalculator::swapBytes(*decimal128);
+                int64_t offset_and_size = writer.writeUnalignedBytes(i, buf.data(), buf.size(), 0);
                 memcpy(buffer_address + offsets[i] + field_offset, &offset_and_size, 8);
             }
         }
@@ -509,6 +536,18 @@ bool BackingDataLengthCalculator::isDataTypeSupportRawData(const DB::DataTypePtr
     return isFixedLengthDataType(type_without_nullable) || which.isStringOrFixedString() || which.isDecimal128();
 }
 
+bool BackingDataLengthCalculator::isBigEndianInSparkRow(const DB::DataTypePtr & type_without_nullable)
+{
+    const WhichDataType which(type_without_nullable);
+    return which.isDecimal128();
+}
+
+void BackingDataLengthCalculator::swapBytes(DB::Decimal128 & decimal128)
+{
+    auto & x = decimal128.value;
+    for (size_t i = 0; i != std::size(x.items); ++i)
+        x.items[i] = __builtin_bswap64(x.items[i]);
+}
 
 VariableLengthDataWriter::VariableLengthDataWriter(
     const DataTypePtr & type_, char * buffer_address_, const std::vector<int64_t> & offsets_, std::vector<int64_t> & buffer_cursor_)
@@ -694,9 +733,10 @@ int64_t VariableLengthDataWriter::write(size_t row_idx, const DB::Field & field,
 
     if (which.isDecimal128())
     {
-        // const auto & decimal = field.get<DecimalField<Decimal128>>();
-        // const auto value = decimal.getValue();
-        return writeUnalignedBytes(row_idx, &field.reinterpret<char>(), sizeof(Decimal128), parent_offset);
+        const auto & decimal_field = field.reinterpret<DecimalField<Decimal128>>();
+        auto decimal128 = decimal_field.getValue();
+        BackingDataLengthCalculator::swapBytes(decimal128);
+        return writeUnalignedBytes(row_idx, reinterpret_cast<const char *>(&decimal128), sizeof(Decimal128), parent_offset);
     }
 
     if (which.isArray())

--- a/utils/local-engine/Parser/CHColumnToSparkRow.h
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.h
@@ -91,6 +91,12 @@ public:
     /// If Data Type can use raw data between CH Column and Spark Row if value is not null
     static bool isDataTypeSupportRawData(const DB::DataTypePtr & type_without_nullable);
 
+    /// If bytes in Spark Row is big-endian. If true, we have to transform them to little-endian afterwords
+    static bool isBigEndianInSparkRow(const DB::DataTypePtr & type_without_nullable);
+
+    /// Convert Field(little-endian) with type Decimal128 to buffer in Spark Row(big-endian)
+    static void swapBytes(DB::Decimal128 & decimal128);
+
     static int64_t getOffsetAndSize(int64_t cursor, int64_t size);
     static int64_t extractOffset(int64_t offset_and_size);
     static int64_t extractSize(int64_t offset_and_size);
@@ -120,7 +126,7 @@ public:
     /// parent_offset: the starting offset of current structure in which we are updating it's backing data region
     virtual int64_t write(size_t row_idx, const DB::Field & field, int64_t parent_offset);
 
-    /// Only support String/FixedString/Decimal32/Decimal64
+    /// Only support String/FixedString/Decimal128
     int64_t writeUnalignedBytes(size_t row_idx, const char * src, size_t size, int64_t parent_offset);
 private:
     int64_t writeArray(size_t row_idx, const DB::Array & array, int64_t parent_offset);

--- a/utils/local-engine/Parser/SparkRowToCHColumn.h
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.h
@@ -170,6 +170,7 @@ public:
         , bit_set_width_in_bytes(calculateBitSetWidthInBytes(num_fields))
         , field_offsets(num_fields)
         , support_raw_datas(num_fields)
+        , is_big_endians_in_spark_row(num_fields)
         , fixed_length_data_readers(num_fields)
         , variable_length_data_readers(num_fields)
     {
@@ -178,6 +179,7 @@ public:
             const auto type_without_nullable = removeNullable(field_types[ordinal]);
             field_offsets[ordinal] = bit_set_width_in_bytes + ordinal * 8L;
             support_raw_datas[ordinal] = BackingDataLengthCalculator::isDataTypeSupportRawData(type_without_nullable);
+            is_big_endians_in_spark_row[ordinal] = BackingDataLengthCalculator::isBigEndianInSparkRow(type_without_nullable);
             if (BackingDataLengthCalculator::isFixedLengthDataType(type_without_nullable))
                 fixed_length_data_readers[ordinal] = std::make_shared<FixedLengthDataReader>(field_types[ordinal]);
             else if (BackingDataLengthCalculator::isVariableLengthDataType(type_without_nullable))
@@ -196,6 +198,12 @@ public:
     {
         assertIndexIsValid(ordinal);
         return support_raw_datas[ordinal];
+    }
+
+    bool isBigEndianInSparkRow(int ordinal) const
+    {
+        assertIndexIsValid(ordinal);
+        return is_big_endians_in_spark_row[ordinal];
     }
 
     std::shared_ptr<FixedLengthDataReader> getFixedLengthDataReader(int ordinal) const
@@ -361,6 +369,7 @@ private:
     const int32_t bit_set_width_in_bytes;
     std::vector<int64_t> field_offsets;
     std::vector<bool> support_raw_datas;
+    std::vector<bool> is_big_endians_in_spark_row;
     std::vector<std::shared_ptr<FixedLengthDataReader>> fixed_length_data_readers;
     std::vector<std::shared_ptr<VariableLengthDataReader>> variable_length_data_readers;
 


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix decimal bug cased by big-endian encoding in spark row. Close https://github.com/Kyligence/ClickHouse/issues/225

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
