### PR TITLE
[CH-262] Skip memory copy between onheap and native when using columnar shuffle manager

### DIFF
--- a/utils/local-engine/Builder/BroadCastJoinBuilder.cpp
+++ b/utils/local-engine/Builder/BroadCastJoinBuilder.cpp
@@ -24,6 +24,7 @@ struct StorageJoinContext
 {
     std::string key;
     jobject input;
+    size_t io_buffer_size;
     DB::Names key_names;
     DB::ASTTableJoin::Kind kind;
     DB::ASTTableJoin::Strictness strictness;
@@ -33,6 +34,7 @@ struct StorageJoinContext
 void BroadCastJoinBuilder::buildJoinIfNotExist(
     const std::string & key,
     jobject input,
+    size_t io_buffer_size,
     const DB::Names & key_names_,
     DB::ASTTableJoin::Kind kind_,
     DB::ASTTableJoin::Strictness strictness_,
@@ -45,7 +47,7 @@ void BroadCastJoinBuilder::buildJoinIfNotExist(
         {
             StorageJoinContext context
             {
-                key, input, key_names_, kind_, strictness_, columns_
+                key, input, io_buffer_size, key_names_, kind_, strictness_, columns_
             };
             // use another thread, exclude broadcast memory allocation from current memory tracker
             auto func = [context]() -> void
@@ -58,7 +60,7 @@ void BroadCastJoinBuilder::buildJoinIfNotExist(
                     storage_join_map.erase(tmp);
                 }
                 auto storage_join = std::make_shared<StorageJoinFromReadBuffer>(
-                    std::make_unique<ReadBufferFromJavaInputStream>(context.input),
+                    std::make_unique<ReadBufferFromJavaInputStream>(context.input, context.io_buffer_size),
                     StorageID("default", context.key),
                     context.key_names,
                     true,
@@ -91,6 +93,7 @@ std::shared_ptr<StorageJoinFromReadBuffer> BroadCastJoinBuilder::getJoin(const s
  void BroadCastJoinBuilder::buildJoinIfNotExist(
     const std::string & key,
     jobject input,
+    size_t io_buffer_size,
     const std::string & join_keys,
     const std::string & join_type,
     const std::string & named_struct)
@@ -133,7 +136,7 @@ std::shared_ptr<StorageJoinFromReadBuffer> BroadCastJoinBuilder::getJoin(const s
 
     Block header = SerializedPlanParser::parseNameStruct(*substrait_struct);
     ColumnsDescription columns_description(header.getNamesAndTypesList());
-    buildJoinIfNotExist(key, input, key_names, kind, strictness, columns_description);
+    buildJoinIfNotExist(key, input, io_buffer_size, key_names, kind, strictness, columns_description);
 }
 void BroadCastJoinBuilder::clean()
 {

--- a/utils/local-engine/Builder/BroadCastJoinBuilder.h
+++ b/utils/local-engine/Builder/BroadCastJoinBuilder.h
@@ -10,6 +10,7 @@ public:
     static void buildJoinIfNotExist(
         const std::string & key,
         jobject input,
+        size_t io_buffer_size,
         const DB::Names & key_names_,
         DB::ASTTableJoin::Kind kind_,
         DB::ASTTableJoin::Strictness strictness_,
@@ -18,6 +19,7 @@ public:
     static void buildJoinIfNotExist(
         const std::string & key,
         jobject input,
+        size_t io_buffer_size,
         const std::string & join_keys,
         const std::string & join_type,
         const std::string & named_struct);

--- a/utils/local-engine/Shuffle/ShuffleReader.cpp
+++ b/utils/local-engine/Shuffle/ShuffleReader.cpp
@@ -51,31 +51,17 @@ bool ReadBufferFromJavaInputStream::nextImpl()
 int ReadBufferFromJavaInputStream::readFromJava()
 {
     GET_JNIENV(env)
-    if (buf == nullptr)
-    {
-        jbyteArray local_buf = env->NewByteArray(4096);
-        buf = static_cast<jbyteArray>(env->NewGlobalRef(local_buf));
-        env->DeleteLocalRef(local_buf);
-    }
-    jint count = safeCallIntMethod(env, java_in, ShuffleReader::input_stream_read, buf);
-    if (count > 0)
-    {
-        env->GetByteArrayRegion(buf, 0, count, reinterpret_cast<jbyte *>(internal_buffer.begin()));
-    }
+    jint count = safeCallIntMethod(env, java_in, ShuffleReader::input_stream_read, reinterpret_cast<jlong>(working_buffer.begin()), buffer_size);
     CLEAN_JNIENV
     return count;
 }
-ReadBufferFromJavaInputStream::ReadBufferFromJavaInputStream(jobject input_stream) : java_in(input_stream)
+ReadBufferFromJavaInputStream::ReadBufferFromJavaInputStream(jobject input_stream, size_t customize_buffer_size) : java_in(input_stream), buffer_size(customize_buffer_size)
 {
 }
 ReadBufferFromJavaInputStream::~ReadBufferFromJavaInputStream()
 {
     GET_JNIENV(env)
     env->DeleteGlobalRef(java_in);
-    if (buf != nullptr)
-    {
-        env->DeleteGlobalRef(buf);
-    }
     CLEAN_JNIENV
 
 }

--- a/utils/local-engine/Shuffle/ShuffleReader.h
+++ b/utils/local-engine/Shuffle/ShuffleReader.h
@@ -29,12 +29,12 @@ private:
 class ReadBufferFromJavaInputStream : public DB::BufferWithOwnMemory<DB::ReadBuffer>
 {
 public:
-    explicit ReadBufferFromJavaInputStream(jobject input_stream);
+    explicit ReadBufferFromJavaInputStream(jobject input_stream, size_t customize_buffer_size);
     ~ReadBufferFromJavaInputStream() override;
 
 private:
     jobject java_in;
-    jbyteArray buf = nullptr;
+    size_t buffer_size;
     int readFromJava();
     bool nextImpl() override;
 

--- a/utils/local-engine/Shuffle/ShuffleSplitter.cpp
+++ b/utils/local-engine/Shuffle/ShuffleSplitter.cpp
@@ -60,7 +60,7 @@ void ShuffleSplitter::splitBlockByPartition(DB::Block & block)
     {
         split_result.raw_partition_length[i] += partitions[i].bytes();
         ColumnsBuffer & buffer = partition_buffer[i];
-        size_t first_cache_count = std::min(partitions[i].rows(), options.buffer_size - buffer.size());
+        size_t first_cache_count = std::min(partitions[i].rows(), options.split_size - buffer.size());
         if (first_cache_count < partitions[i].rows())
         {
             buffer.add(partitions[i], 0, first_cache_count);
@@ -71,7 +71,7 @@ void ShuffleSplitter::splitBlockByPartition(DB::Block & block)
         {
             buffer.add(partitions[i], 0, first_cache_count);
         }
-        if (buffer.size() == options.buffer_size)
+        if (buffer.size() == options.split_size)
         {
             spillPartition(i);
         }
@@ -79,7 +79,7 @@ void ShuffleSplitter::splitBlockByPartition(DB::Block & block)
 }
 void ShuffleSplitter::init()
 {
-    partition_ids.reserve(options.buffer_size);
+    partition_ids.reserve(options.split_size);
     partition_buffer.reserve(options.partition_nums);
     partition_outputs.reserve(options.partition_nums);
     partition_write_buffers.reserve(options.partition_nums);
@@ -127,12 +127,12 @@ void ShuffleSplitter::mergePartitionFiles()
 {
     DB::WriteBufferFromFile data_write_buffer = DB::WriteBufferFromFile(options.data_file);
     std::string buffer;
-    int buffer_size = 1024 * 1024;
+    int buffer_size = options.io_buffer_size;
     buffer.reserve(buffer_size);
     for (size_t i = 0; i < options.partition_nums; ++i)
     {
         auto file = getPartitionTempFile(i);
-        DB::ReadBufferFromFile reader = DB::ReadBufferFromFile(file);
+        DB::ReadBufferFromFile reader = DB::ReadBufferFromFile(file, options.io_buffer_size);
         while (reader.next())
         {
             auto bytes = reader.readBig(buffer.data(), buffer_size);
@@ -188,7 +188,7 @@ std::unique_ptr<DB::WriteBuffer> ShuffleSplitter::getPartitionWriteBuffer(size_t
     auto file = getPartitionTempFile(partition_id);
     if (partition_cached_write_buffers[partition_id] == nullptr)
         partition_cached_write_buffers[partition_id]
-            = std::make_unique<DB::WriteBufferFromFile>(file, DBMS_DEFAULT_BUFFER_SIZE, O_CREAT | O_WRONLY | O_APPEND);
+            = std::make_unique<DB::WriteBufferFromFile>(file, options.io_buffer_size, O_CREAT | O_WRONLY | O_APPEND);
     if (!options.compress_method.empty()
         && std::find(compress_methods.begin(), compress_methods.end(), options.compress_method) != compress_methods.end())
     {
@@ -206,7 +206,7 @@ const std::vector<std::string> ShuffleSplitter::compress_methods = {"", "ZSTD", 
 void ShuffleSplitter::writeIndexFile()
 {
     auto index_file = options.data_file + ".index";
-    auto writer = std::make_unique<DB::WriteBufferFromFile>(index_file, DBMS_DEFAULT_BUFFER_SIZE, O_CREAT | O_WRONLY | O_TRUNC);
+    auto writer = std::make_unique<DB::WriteBufferFromFile>(index_file, options.io_buffer_size, O_CREAT | O_WRONLY | O_TRUNC);
     for (auto len : split_result.partition_length)
     {
         DB::writeIntText(len, *writer);

--- a/utils/local-engine/Shuffle/ShuffleSplitter.h
+++ b/utils/local-engine/Shuffle/ShuffleSplitter.h
@@ -14,7 +14,8 @@ namespace local_engine
 {
 struct SplitOptions
 {
-    size_t buffer_size = DEFAULT_BLOCK_SIZE;
+    size_t split_size = DEFAULT_BLOCK_SIZE;
+    size_t io_buffer_size = DBMS_DEFAULT_BUFFER_SIZE;
     std::string data_file;
     std::string local_tmp_dir;
     int map_id;

--- a/utils/local-engine/Shuffle/ShuffleWriter.cpp
+++ b/utils/local-engine/Shuffle/ShuffleWriter.cpp
@@ -1,19 +1,35 @@
 #include "ShuffleWriter.h"
+#include <Compression/CompressedWriteBuffer.h>
+#include <Compression/CompressionFactory.h>
+#include <boost/algorithm/string/case_conv.hpp>
 
 using namespace DB;
 
 namespace local_engine
 {
 
-ShuffleWriter::ShuffleWriter(jobject output_stream, jbyteArray buffer)
+ShuffleWriter::ShuffleWriter(jobject output_stream, jbyteArray buffer, const std::string & codecStr, bool enable_compression, size_t customize_buffer_size)
 {
-    write_buffer = std::make_unique<WriteBufferFromJavaOutputStream>(output_stream, buffer);
+    compression_enable = enable_compression;
+    write_buffer = std::make_unique<WriteBufferFromJavaOutputStream>(output_stream, buffer, customize_buffer_size);
+    if (compression_enable)
+    {
+        auto codec = DB::CompressionCodecFactory::instance().get(boost::to_upper_copy(codecStr), {});
+        compressed_out = std::make_unique<CompressedWriteBuffer>(*write_buffer, codec);
+    }
 }
 void ShuffleWriter::write(const Block & block)
 {
     if (!native_writer)
     {
-        native_writer = std::make_unique<NativeWriter>(*write_buffer, 0, block.cloneEmpty());
+        if (compression_enable)
+        {
+            native_writer = std::make_unique<NativeWriter>(*compressed_out, 0, block.cloneEmpty());
+        }
+        else
+        {
+            native_writer = std::make_unique<NativeWriter>(*write_buffer, 0, block.cloneEmpty());
+        }
     }
     if (block.rows() > 0)
     {
@@ -32,6 +48,10 @@ ShuffleWriter::~ShuffleWriter()
     if (native_writer)
     {
         native_writer->flush();
+        if (compression_enable)
+        {
+            compressed_out->finalize();
+        }
         write_buffer->finalize();
     }
 }

--- a/utils/local-engine/Shuffle/ShuffleWriter.h
+++ b/utils/local-engine/Shuffle/ShuffleWriter.h
@@ -7,13 +7,15 @@ namespace local_engine
 class ShuffleWriter
 {
 public:
-    ShuffleWriter(jobject output_stream, jbyteArray buffer);
+    ShuffleWriter(jobject output_stream, jbyteArray buffer, const std::string & codecStr, bool enable_compression, size_t customize_buffer_size);
     virtual ~ShuffleWriter();
     void write(const DB::Block & block);
     void flush();
 
 private:
+    std::unique_ptr<DB::CompressedWriteBuffer> compressed_out;
     std::unique_ptr<WriteBufferFromJavaOutputStream> write_buffer;
     std::unique_ptr<DB::NativeWriter> native_writer;
+    bool compression_enable;
 };
 }

--- a/utils/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
+++ b/utils/local-engine/Shuffle/WriteBufferFromJavaOutputStream.cpp
@@ -21,12 +21,12 @@ void WriteBufferFromJavaOutputStream::nextImpl()
     }
     CLEAN_JNIENV
 }
-WriteBufferFromJavaOutputStream::WriteBufferFromJavaOutputStream(jobject output_stream_, jbyteArray buffer_)
+WriteBufferFromJavaOutputStream::WriteBufferFromJavaOutputStream(jobject output_stream_, jbyteArray buffer_, size_t customize_buffer_size)
 {
     GET_JNIENV(env)
     buffer = static_cast<jbyteArray>(env->NewWeakGlobalRef(buffer_));
     output_stream = env->NewWeakGlobalRef(output_stream_);
-    buffer_size = env->GetArrayLength(buffer);
+    buffer_size = customize_buffer_size;
     CLEAN_JNIENV
 }
 void WriteBufferFromJavaOutputStream::finalizeImpl()

--- a/utils/local-engine/Shuffle/WriteBufferFromJavaOutputStream.h
+++ b/utils/local-engine/Shuffle/WriteBufferFromJavaOutputStream.h
@@ -12,7 +12,7 @@ public:
     static jmethodID output_stream_write;
     static jmethodID output_stream_flush;
 
-    WriteBufferFromJavaOutputStream(jobject output_stream, jbyteArray buffer);
+    WriteBufferFromJavaOutputStream(jobject output_stream, jbyteArray buffer, size_t customize_buffer_size);
     ~WriteBufferFromJavaOutputStream() override;
 
 private:

--- a/utils/local-engine/tests/benchmark_local_engine.cpp
+++ b/utils/local-engine/tests/benchmark_local_engine.cpp
@@ -260,7 +260,8 @@ DB::ContextMutablePtr global_context;
         int sum = 0;
         auto root = "/tmp/test_shuffle/" + local_engine::ShuffleSplitter::compress_methods[state.range(1)];
         local_engine::SplitOptions options{
-            .buffer_size = 8192,
+            .split_size = 8192,
+            .io_buffer_size = DBMS_DEFAULT_BUFFER_SIZE,
             .data_file = root + "/data.dat",
             .local_tmp_dir = root,
             .map_id = 1,
@@ -345,7 +346,8 @@ DB::ContextMutablePtr global_context;
         int sum = 0;
         auto root = "/tmp/test_shuffle/" + local_engine::ShuffleSplitter::compress_methods[state.range(1)];
         local_engine::SplitOptions options{
-            .buffer_size = 8192,
+            .split_size = 8192,
+            .io_buffer_size = DBMS_DEFAULT_BUFFER_SIZE,
             .data_file = root + "/data.dat",
             .local_tmp_dir = root,
             .map_id = 1,


### PR DESCRIPTION
Changelog category (leave one):

Skip memory copy between onheap and native when using columnar shuffle manager.


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

