### PR TITLE
[CH-272]Fix union join error

### DIFF
--- a/utils/local-engine/Shuffle/NativeSplitter.cpp
+++ b/utils/local-engine/Shuffle/NativeSplitter.cpp
@@ -170,7 +170,7 @@ HashNativeSplitter::HashNativeSplitter(NativeSplitter::Options options_, jobject
     std::vector<std::string> hash_fields;
     hash_fields.insert(hash_fields.end(), exprs_list.begin(), exprs_list.end());
 
-    selector_builder = std::make_unique<HashSelectorBuilder>(options.partition_nums, hash_fields, "murmurHash3_32");
+    selector_builder = std::make_unique<HashSelectorBuilder>(options.partition_nums, hash_fields, std::vector<std::size_t>(), "murmurHash3_32");
 }
 
 void HashNativeSplitter::computePartitionId(Block & block)

--- a/utils/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/utils/local-engine/Shuffle/SelectorBuilder.cpp
@@ -33,17 +33,30 @@ std::vector<DB::IColumn::ColumnIndex> RoundRobinSelectorBuilder::build(DB::Block
     return result;
 }
 
-HashSelectorBuilder::HashSelectorBuilder(UInt32 parts_num_, const std::vector<std::string> & exprs_, const std::string & hash_function_name_)
-    : parts_num(parts_num_), exprs(exprs_), hash_function_name(hash_function_name_)
+HashSelectorBuilder::HashSelectorBuilder(
+    UInt32 parts_num_,
+    const std::vector<std::string> & exprs_,
+    const std::vector<std::size_t> & exprs_index_,
+    const std::string & hash_function_name_)
+    : parts_num(parts_num_), exprs(exprs_), exprs_index(exprs_index_), hash_function_name(hash_function_name_)
 {
 }
 
 std::vector<DB::IColumn::ColumnIndex> HashSelectorBuilder::build(DB::Block & block)
 {
     ColumnsWithTypeAndName args;
-    for (auto & name : exprs)
+    for (int i = 0; i < exprs.size(); i++)
     {
-        args.emplace_back(block.getByName(name));
+        auto & name = exprs.at(i);
+        auto * type_and_name = block.findByName(name);
+        if (type_and_name == nullptr)
+        {
+            args.emplace_back(block.getByPosition(exprs_index.at(i)));
+        }
+        else
+        {
+            args.emplace_back(block.getByName(name));
+        }
     }
 
     if (!hash_function) [[unlikely]]

--- a/utils/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/utils/local-engine/Shuffle/SelectorBuilder.cpp
@@ -45,7 +45,7 @@ HashSelectorBuilder::HashSelectorBuilder(
 std::vector<DB::IColumn::ColumnIndex> HashSelectorBuilder::build(DB::Block & block)
 {
     ColumnsWithTypeAndName args;
-    for (int i = 0; i < exprs.size(); i++)
+    for (size_t i = 0; i < exprs.size(); i++)
     {
         auto & name = exprs.at(i);
         auto * type_and_name = block.findByName(name);

--- a/utils/local-engine/Shuffle/SelectorBuilder.h
+++ b/utils/local-engine/Shuffle/SelectorBuilder.h
@@ -26,11 +26,16 @@ private:
 class HashSelectorBuilder
 {
 public:
-    explicit HashSelectorBuilder(UInt32 parts_num_, const std::vector<std::string> & exprs_, const std::string & hash_function_name_);
+    explicit HashSelectorBuilder(
+        UInt32 parts_num_,
+        const std::vector<std::string> & exprs_,
+        const std::vector<std::size_t> & exprs_index_,
+        const std::string & hash_function_name_);
     std::vector<DB::IColumn::ColumnIndex> build(DB::Block & block);
 private:
     UInt32 parts_num;
     std::vector<std::string> exprs;
+    std::vector<std::size_t> exprs_index;
     std::string hash_function_name;
     DB::FunctionBasePtr hash_function;
 };

--- a/utils/local-engine/Shuffle/ShuffleSplitter.cpp
+++ b/utils/local-engine/Shuffle/ShuffleSplitter.cpp
@@ -286,7 +286,17 @@ HashSplitter::HashSplitter(SplitOptions options_) : ShuffleSplitter(std::move(op
     std::vector<std::string> hash_fields;
     hash_fields.insert(hash_fields.end(), exprs_list.begin(), exprs_list.end());
 
-    selector_builder = std::make_unique<HashSelectorBuilder>(options.partition_nums, hash_fields, "murmurHash3_32");
+    std::vector<std::size_t> hash_fields_index;
+    if (!options_.exprs_index.empty())
+    {
+        Poco::StringTokenizer exprs_list_index(options_.exprs_index, ",");
+        for (const auto & expr_index : exprs_list_index)
+        {
+            hash_fields_index.insert(hash_fields_index.end(), static_cast<size_t>(stoi(expr_index)));
+        }
+    }
+
+    selector_builder = std::make_unique<HashSelectorBuilder>(options.partition_nums, hash_fields, hash_fields_index, "murmurHash3_32");
 }
 std::unique_ptr<ShuffleSplitter> HashSplitter::create(SplitOptions && options_)
 {

--- a/utils/local-engine/Shuffle/ShuffleSplitter.h
+++ b/utils/local-engine/Shuffle/ShuffleSplitter.h
@@ -21,6 +21,7 @@ struct SplitOptions
     int map_id;
     size_t partition_nums;
     std::string exprs;
+    std::string exprs_index;
     // std::vector<std::string> exprs;
     std::string compress_method = "zstd";
     int compress_level;


### PR DESCRIPTION
Changelog category (leave one):

- Bug Fix
#272 
When `block.findByName` is null, will use `getByPosition` instead of name


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

