### PR TITLE
[CH-300] fix multi aggregation fail due to serialize partial aggregation to aggregation in shuffle

### DIFF
--- a/utils/local-engine/AggregateFunctions/AggregateFunctionPartialMerge.h
+++ b/utils/local-engine/AggregateFunctions/AggregateFunctionPartialMerge.h
@@ -47,7 +47,7 @@ public:
 
     String getName() const override
     {
-        return nested_func->getName() + "Merge";
+        return nested_func->getName() + "PartialMerge";
     }
 
     DataTypePtr getReturnType() const override


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix the bug that multi aggregation fail due to mistake serializing partial aggregation with aggregation in shuffle

> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
