### PR TITLE
[CH-316] Fix memory leak when executing BHJ

### DIFF
--- a/utils/local-engine/Builder/BroadCastJoinBuilder.cpp
+++ b/utils/local-engine/Builder/BroadCastJoinBuilder.cpp
@@ -2,6 +2,7 @@
 #include <Parser/SerializedPlanParser.h>
 #include <Poco/StringTokenizer.h>
 #include <Common/ThreadPool.h>
+#include <Common/JNIUtils.h>
 
 namespace DB
 {
@@ -77,6 +78,14 @@ void BroadCastJoinBuilder::buildJoinIfNotExist(
             ThreadFromGlobalPool build_thread(std::move(func));
             build_thread.join();
         }
+    }
+    else
+    {
+        GET_JNIENV(env)
+        // it needs to delete global ref of the input object, otherwise it will hold the input object
+        // and lead to memory leak.
+        env->DeleteGlobalRef(input);
+        CLEAN_JNIENV
     }
 }
 std::shared_ptr<StorageJoinFromReadBuffer> BroadCastJoinBuilder::getJoin(const std::string & key)


### PR DESCRIPTION
When executing BHJ, there are some JVM Object not to be GC and lead to memory leak.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehavior in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
