### PR TITLE
Fix bug when struct contains decimal types

### DIFF
--- a/utils/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -719,7 +719,8 @@ int64_t VariableLengthDataWriter::writeStruct(size_t row_idx, const DB::Tuple & 
         {
             FixedLengthDataWriter writer(field_type);
             // writer.write(field_value, buffer_address + offset + start + len_null_bitmap + i * 8);
-            writer.unsafeWrite(reinterpret_cast<char*>(&field_value.safeGet<char>()), buffer_address + offset + start + len_null_bitmap + i * 8);
+            writer.unsafeWrite(
+                reinterpret_cast<const char *>(&field_value.get<char>()), buffer_address + offset + start + len_null_bitmap + i * 8);
         }
         else
         {


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix bug when struct contains decimal types. It is found in pr: https://github.com/oap-project/gluten/pull/897

```
CREATE TEMPORARY VIEW nation
USING org.apache.spark.sql.parquet
OPTIONS (
  path  "/data1/liyang/cppproject/gluten/gluten-core/src/test/resources/tpch-data/nation"
) ;


select n_nationkey, named_struct("a", n_nationkey, "b", n_regionkey, "c", 2.0) as t from nation; 
```

![image](https://user-images.githubusercontent.com/8181003/222324592-f2707892-fa2a-4a56-87b6-bdbb2bc428f6.png)


