### PR TITLE
Fix decimal128 value error

### DIFF
--- a/utils/local-engine/Parser/CHColumnToSparkRow.h
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.h
@@ -94,10 +94,9 @@ public:
     /// If bytes in Spark Row is big-endian. If true, we have to transform them to little-endian afterwords
     static bool isBigEndianInSparkRow(const DB::DataTypePtr & type_without_nullable);
 
-    /// Convert Field with type Decimal128 to/from buffer in Spark Row(big-endian)
-    static void swapBytes(DB::Decimal128 & decimal128);
-
     /// Convert endian. Big to little or little to big.
+    /// Note: Spark unsafeRow biginteger is big-endian.
+    ///       CH Int128 is little-endian, is same as system(std::endian::native).
     static void swapDecimalEndianBytes(String & buf);
 
     static int64_t getOffsetAndSize(int64_t cursor, int64_t size);

--- a/utils/local-engine/Parser/CHColumnToSparkRow.h
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.h
@@ -97,9 +97,8 @@ public:
     /// Convert Field with type Decimal128 to/from buffer in Spark Row(big-endian)
     static void swapBytes(DB::Decimal128 & decimal128);
 
-    /// Get Decimal128 from substrait decimal literal bytes
-    /// Note: bytes is little-endian, but Int128 has big-endian array containing two little-endian uint64_t
-    static DB::Decimal128 getDecimal128FromBytes(const String & bytes);
+    /// Convert endian. Big to little or little to big.
+    static void swapDecimalEndianBytes(String & buf);
 
     static int64_t getOffsetAndSize(int64_t cursor, int64_t size);
     static int64_t extractOffset(int64_t offset_and_size);

--- a/utils/local-engine/Parser/SerializedPlanParser.cpp
+++ b/utils/local-engine/Parser/SerializedPlanParser.cpp
@@ -1748,7 +1748,8 @@ std::pair<DataTypePtr, Field> SerializedPlanParser::parseLiteral(const substrait
             else if (precision <= DataTypeDecimal128::maxPrecision())
             {
                 type = std::make_shared<DataTypeDecimal128>(precision, scale);
-                auto value = BackingDataLengthCalculator::getDecimal128FromBytes(bytes);
+                String bytes_copy(bytes);
+                auto value = *reinterpret_cast<Decimal128 *>(bytes_copy.data());
                 field = DecimalField<Decimal128>(value, scale);
             }
             else

--- a/utils/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -47,9 +47,10 @@ ALWAYS_INLINE static void writeRowToColumns(std::vector<MutableColumnPtr> & colu
                 columns[i]->insertData(str_ref.data, str_ref.size);
             else
             {
-                String str(str_ref.data, str_ref.size);
-                auto * decimal128 = reinterpret_cast<Decimal128 *>(str.data());
-                BackingDataLengthCalculator::swapBytes(*decimal128);
+                char decimal128_fix_data[16] = {};
+                memcpy(decimal128_fix_data + 16 - str_ref.size, str_ref.data, str_ref.size);
+                String str(decimal128_fix_data, 16);
+                BackingDataLengthCalculator::swapDecimalEndianBytes(str); // Big-endian to Little-endian
                 columns[i]->insertData(str.data(), str.size());
             }
         }

--- a/utils/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -145,10 +145,11 @@ StringRef VariableLengthDataReader::readUnalignedBytes(const char * buffer, size
 
 Field VariableLengthDataReader::readDecimal(const char * buffer, size_t length) const
 {
-    constexpr int size = sizeof(Decimal128);
-    char decimal128_fix_data[size] = {};
-    memcpy(decimal128_fix_data + size - length, buffer, length); // padding
-    String buf(decimal128_fix_data, size);
+    assert(sizeof(Decimal128) <= length);
+
+    char decimal128_fix_data[sizeof(Decimal128)] = {};
+    memcpy(decimal128_fix_data + sizeof(Decimal128) - length, buffer, length); // padding
+    String buf(decimal128_fix_data, sizeof(Decimal128));
     BackingDataLengthCalculator::swapDecimalEndianBytes(buf); // Big-endian to Little-endian
 
     auto * decimal128 = reinterpret_cast<Decimal128 *>(buf.data());


### PR DESCRIPTION

Substrait plan decimal is Little-endian and unsaferow is Big-endian.


### Changelog category (leave one):
- Bug Fix 
test by sql
```sql
SELECT
cast(1.11 as decimal(20, 3)),
cast(1.123456789 as decimal(20,9)),
cast(123456789.123456789 as decimal(30,9)),
cast(1.12345678901234567890123456789 as decimal(38,29)),
cast(123456789.123456789012345678901234567 as decimal(38,27))
```


Clickhouse中Decimal128是用的wide_integer表示
wide_integer由1个长度为2的Int128(原始类型为int64)数组表示，sizeof(Decimal128)=16
大致表示为
Decimal.value.items
Decimal.value<wide::integer<Int128,int>>.items<wide::integer<Int128,int>::base_type[2]>

Item[0]表示低位，Item[1]表示高位置

以下是一个类型为Decimal128(38, 18)，值为123456789.123456789012345678901234567的表示法
Item[0]=17502027876307000320    低位
item[1]=6692605                               高位

17502027876307000320的地址上数据为 00 5c 43 b0   9f b1 e3 f2，左边低位
6692605的地址上数据为 fd 1e 66 00   00 00 00 00，左边低位

合并到一起 00 5c 43 b0   9f b1 e3 f2   fd 1e 66 00   00 00 00 00，左边低位
如果把完整的地址翻译成Int128，那么就是 123456789.123456789012345678901234567。

gluten中和ch交互涉及到decimal转换
因为scala中biginteger有大小端的问题，这里总结下
scala中biginteger是大端，而ch接收是小端

入口
substrait传入的定值
如
//这里只是举例
select toDecimal(123456789.123456789012345678901234567, 18)
这里是通过DecimalLiteralNode.java来完成，通过encodeDecimalIntoBytes获取传入的bytes，这里作了大小端的转换，所以ch接收到的时候，直接转换

从Java Iterator中读取的Decimal
这部分数据属于unsaferow，由spark的biginteger序列化得到大端，所以ch接收后需要转换成小端。
接收到是
66 1e fd f2   e3 b1 9f b0   43 5c 00 00   00 00 00 00

这里有一个问题是decimal的str长度是11，尾部的0是为了对齐8来补充的，而ch需要16长的直接来转换，这里需要在低地址处补齐0。等endian转换后，自动到了高地址
补齐后是
00 00 00 00 00 66 1e fd   f2 e3 b1 9f   b0 43 5c 00

出口
ColumnarToRow时，CH的decimal内存拷贝
这里存在nullable和非nullable，都需要转。由小端转成大端顺序

为啥会存在大小端转换
scala bigint转成byteArray时按照大端来的
Returns a byte array containing the two's-complement representation of this BigInt. The byte array will be in big-endian byte-order: the most significant byte is in the zeroth element. The array will contain the minimum number of bytes required to represent this BigInt, including at least one sign bit.
https://www.scala-lang.org/api/2.12.1/scala/math/BigInt.html

