### PR TITLE
[CH-358]Support json_tuple function

### DIFF
--- a/utils/local-engine/Parser/CHColumnToSparkRow.cpp
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.cpp
@@ -4,6 +4,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnConst.h>
 #include <Columns/IColumn.h>
 #include <Core/Types.h>
 #include <DataTypes/DataTypeArray.h>
@@ -12,6 +13,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <DataTypes/ObjectUtils.h>
 #include <Common/Exception.h>
 
 namespace DB
@@ -232,10 +234,10 @@ static void writeValue(
         throw Exception(ErrorCodes::UNKNOWN_TYPE, "Doesn't support type {} for writeValue", col.type->getName());
 }
 
-SparkRowInfo::SparkRowInfo(const Block & block)
-    : types(std::move(block.getDataTypes()))
-    , num_rows(block.rows())
-    , num_cols(block.columns())
+SparkRowInfo::SparkRowInfo(const DB::ColumnsWithTypeAndName & cols, const DB::DataTypes & types, const size_t & col_size, const size_t & row_size)
+    : types(types)
+    , num_rows(row_size)
+    , num_cols(col_size)
     , null_bitset_width_in_bytes(calculateBitSetWidthInBytes(num_cols))
     , total_bytes(0)
     , offsets(num_rows, 0)
@@ -254,8 +256,7 @@ SparkRowInfo::SparkRowInfo(const Block & block)
 
     for (int64_t col_idx = 0; col_idx < num_cols; ++col_idx)
     {
-        const auto & col = block.getByPosition(col_idx);
-
+        const auto & col = cols[col_idx];
         /// No need to calculate backing data length for fixed length types
         const auto type_without_nullable = removeNullable(col.type);
         if (BackingDataLengthCalculator::isVariableLengthDataType(type_without_nullable))
@@ -298,6 +299,8 @@ SparkRowInfo::SparkRowInfo(const Block & block)
     for (int64_t i = 0; i < num_rows; ++i)
         total_bytes += lengths[i];
 }
+
+SparkRowInfo::SparkRowInfo(const Block & block) : SparkRowInfo(block.getColumnsWithTypeAndName(), block.getDataTypes(), block.columns(), block.rows()){}
 
 const DB::DataTypes & SparkRowInfo::getDataTypes() const
 {
@@ -374,13 +377,55 @@ std::unique_ptr<SparkRowInfo> CHColumnToSparkRow::convertCHColumnToSparkRow(cons
     if (!block.columns())
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "A block with empty columns");
 
-    std::unique_ptr<SparkRowInfo> spark_row_info = std::make_unique<SparkRowInfo>(block);
+    auto block_col = block.getByPosition(0);
+    DB::ColumnPtr nested_col = block_col.column;
+    if (const auto * const_col = checkAndGetColumn<DB::ColumnConst>(nested_col.get()))
+    {
+        nested_col = const_col->getDataColumnPtr();
+    }
+    if (const auto * nullable_col = checkAndGetColumn<DB::ColumnNullable>(nested_col.get()))
+    {
+        nested_col = nullable_col->getNestedColumnPtr();
+    }
+    std::unique_ptr<SparkRowInfo> spark_row_info;
+    DB::ColumnsWithTypeAndName columns;
+    if (nested_col->getDataType() == DB::TypeIndex::Tuple)
+    {
+        const auto * tuple_col = checkAndGetColumn<DB::ColumnTuple>(nested_col.get());
+        const size_t col_size = tuple_col->tupleSize();
+        const size_t row_size = block.rows();
+        DB::DataTypes data_types;
+        for (size_t i = 0; i < col_size; i++)
+        {
+            const auto & field_col = tuple_col->getColumn(i);
+            DataTypePtr field_type;
+            if (field_col.isNullable())
+            {
+                const auto & field_nested_col= assert_cast<const ColumnNullable &>(field_col).getNestedColumn();
+                DataTypePtr field_nested_type = getDataTypeByColumn(field_nested_col);
+                field_type = std::make_shared<DB::DataTypeNullable>(field_nested_type);
+            }
+            else
+            {
+                field_type = getDataTypeByColumn(field_col);
+            }
+            DB::ColumnWithTypeAndName col_type_name(tuple_col->getColumnPtr(i), field_type, "c" + std::to_string(i));
+            columns.emplace_back(col_type_name);
+            data_types.emplace_back(field_type);
+        }
+        spark_row_info = std::make_unique<SparkRowInfo>(columns, data_types, col_size, row_size);
+    }
+    else
+    {
+        spark_row_info = std::make_unique<SparkRowInfo>(block);
+        columns = block.getColumnsWithTypeAndName();
+    }
     spark_row_info->setBufferAddress(reinterpret_cast<char *>(alloc(spark_row_info->getTotalBytes(), 64)));
     // spark_row_info->setBufferAddress(alignedAlloc(spark_row_info->getTotalBytes(), 64));
     memset(spark_row_info->getBufferAddress(), 0, spark_row_info->getTotalBytes());
     for (auto col_idx = 0; col_idx < spark_row_info->getNumCols(); col_idx++)
     {
-        const auto & col = block.getByPosition(col_idx);
+        const auto & col = columns[col_idx];
         int64_t field_offset = spark_row_info->getFieldOffset(col_idx);
 
         ColumnWithTypeAndName col_not_const{col.column->convertToFullColumnIfConst(), col.type, col.name};

--- a/utils/local-engine/Parser/CHColumnToSparkRow.h
+++ b/utils/local-engine/Parser/CHColumnToSparkRow.h
@@ -23,6 +23,7 @@ class SparkRowInfo : public boost::noncopyable
 
 public:
     explicit SparkRowInfo(const DB::Block & block);
+    explicit SparkRowInfo(const DB::ColumnsWithTypeAndName & cols, const DB::DataTypes & types, const size_t & col_size, const size_t & row_size);
 
     const DB::DataTypes & getDataTypes() const;
 

--- a/utils/local-engine/Parser/SerializedPlanParser.cpp
+++ b/utils/local-engine/Parser/SerializedPlanParser.cpp
@@ -700,7 +700,7 @@ QueryPlanPtr SerializedPlanParser::parse(std::unique_ptr<substrait::Plan> plan)
             ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(blockToNameAndTypeList(query_plan->getCurrentDataStream().header));
             NamesWithAliases aliases;
             auto cols = query_plan->getCurrentDataStream().header.getNamesAndTypesList();
-            for (int i = 0; i < cols.getNames().size(); i++)
+            for (size_t i = 0; i < cols.getNames().size(); i++)
             {
                 aliases.emplace_back(NameWithAlias(cols.getNames()[i], root_rel.root().names(i)));
             }
@@ -1645,6 +1645,34 @@ void SerializedPlanParser::parseFunctionArguments(
         function_name = "repeat";
         parsed_args.emplace_back(space_str_node);
         parsed_args.emplace_back(repeat_times_node);
+    }
+    else if (function_name == "json_tuple")
+    {
+        function_name = "JSONExtract";
+        const DB::ActionsDAG::Node * json_expr_node = parseFunctionArgument(actions_dag, required_columns, "JSONExtract", args[0]);
+        std::string extract_expr = "Tuple(";
+        for (int i = 1; i < args.size(); i++)
+        {
+            auto arg_value = args[i].value();
+            if (!arg_value.has_literal())
+            {
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "The arguments of function {} must be string literal", function_name);
+            }
+            DB::Field f = arg_value.literal().string();
+            std::string s;
+            if (f.tryGet(s))
+            {
+                extract_expr.append(s).append(" Nullable(String)");
+                if (i != args.size() - 1)
+                {
+                    extract_expr.append(",");
+                }
+            }
+        }
+        extract_expr.append(")");
+        const DB::ActionsDAG::Node * extract_expr_node = add_column(std::make_shared<DataTypeString>(), extract_expr);
+        parsed_args.emplace_back(json_expr_node);
+        parsed_args.emplace_back(extract_expr_node);
     }
     else
     {

--- a/utils/local-engine/Parser/SerializedPlanParser.cpp
+++ b/utils/local-engine/Parser/SerializedPlanParser.cpp
@@ -700,7 +700,7 @@ QueryPlanPtr SerializedPlanParser::parse(std::unique_ptr<substrait::Plan> plan)
             ActionsDAGPtr actions_dag = std::make_shared<ActionsDAG>(blockToNameAndTypeList(query_plan->getCurrentDataStream().header));
             NamesWithAliases aliases;
             auto cols = query_plan->getCurrentDataStream().header.getNamesAndTypesList();
-            for (int i = 0; i < root_rel.root().names_size(); i++)
+            for (int i = 0; i < cols.getNames().size(); i++)
             {
                 aliases.emplace_back(NameWithAlias(cols.getNames()[i], root_rel.root().names(i)));
             }

--- a/utils/local-engine/Parser/SerializedPlanParser.h
+++ b/utils/local-engine/Parser/SerializedPlanParser.h
@@ -188,6 +188,7 @@ static const std::map<std::string, std::string> SCALAR_FUNCTIONS = {
     {"get_json_object", "JSON_VALUE"},
     {"to_json", "toJSONString"},
     {"from_json", "JSONExtract"},
+    {"json_tuple", "json_tuple"}
 };
 
 static const std::set<std::string> FUNCTION_NEED_KEEP_ARGUMENTS = {"alias"};


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Implement json_tuple funtion by use JSONExtract function in ck, the releated issue: https://github.com/Kyligence/ClickHouse/issues/358
1. convert json_tuple to JSONExtract function;
2. convert json_tuple result to multi columns likes spark json_tuple

