### PR TITLE
[CH-362] fix bad_alloc when converting spark rows to ch column

### DIFF
--- a/utils/local-engine/Parser/SparkRowToCHColumn.cpp
+++ b/utils/local-engine/Parser/SparkRowToCHColumn.cpp
@@ -169,7 +169,7 @@ Field VariableLengthDataReader::readArray(const char * buffer, [[maybe_unused]] 
     /// Read numElements
     int64_t num_elems = 0;
     memcpy(&num_elems, buffer, 8);
-    if (num_elems == 0)
+    if (num_elems == 0 || length == 0)
         return Array();
 
     /// Skip null_bitmap
@@ -232,7 +232,7 @@ Field VariableLengthDataReader::readMap(const char * buffer, size_t length) cons
     /// Read Length of UnsafeArrayData of key
     int64_t key_array_size = 0;
     memcpy(&key_array_size, buffer, 8);
-    if (key_array_size == 0)
+    if (key_array_size == 0 || length == 0)
         return std::move(Map());
 
     /// Read UnsafeArrayData of keys


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix the bug that it may throw bad_alloc exception when converting spark rows to ch column

This pr close #362 .