### PR TITLE
Fix some asan complain about inside_main

### DIFF
--- a/utils/local-engine/local_engine_jni.cpp
+++ b/utils/local-engine/local_engine_jni.cpp
@@ -27,8 +27,6 @@
 #include <Common/QueryContext.h>
 
 
-bool inside_main = true;
-
 #ifdef __cplusplus
 std::vector<std::string> stringSplit(const std::string & str, char delim)
 {

--- a/utils/local-engine/tests/benchmark_local_engine.cpp
+++ b/utils/local-engine/tests/benchmark_local_engine.cpp
@@ -48,7 +48,6 @@
 using namespace local_engine;
 using namespace dbms;
 
-bool inside_main = true;
 DB::ContextMutablePtr global_context;
 
 [[maybe_unused]] static void BM_CHColumnToSparkRow(benchmark::State & state)

--- a/utils/local-engine/tests/benchmark_spark_row.cpp
+++ b/utils/local-engine/tests/benchmark_spark_row.cpp
@@ -70,7 +70,7 @@ static void BM_CHColumnToSparkRow_Lineitem(benchmark::State& state)
     };
 
     const Block header = std::move(getLineitemHeader(name_types));
-    const String file = "/data1/liyang/cppproject/gluten/jvm/src/test/resources/tpch-data/lineitem/"
+    const String file = "/data1/liyang/cppproject/gluten/gluten-core/src/test/resources/tpch-data/lineitem/"
                         "part-00000-d08071cb-0dfa-42dc-9198-83cb334ccda3-c000.snappy.parquet";
     Block block;
     readParquetFile(header, file, block);

--- a/utils/local-engine/tests/gtest_local_engine.cpp
+++ b/utils/local-engine/tests/gtest_local_engine.cpp
@@ -86,7 +86,6 @@ TEST(TestSelect, ReadDate)
     }
 }
 
-bool inside_main = true;
 TEST(TestSelect, TestFilter)
 {
     dbms::SerializedSchemaBuilder schema_builder;


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix some asan complain about inside_main

```
=================================================================
==18419==ERROR: AddressSanitizer: odr-violation (0x0000142a1940):
[1] size=1 'inside_main' /data1/liyang/cppproject/kyli/ClickHouse/utils/local-engine/tests/gtest_local_engine.cpp:89:6
[2] size=1 'inside_main' /data1/liyang/cppproject/kyli/ClickHouse/utils/local-engine/local_engine_jni.cpp:30:6
These globals were registered at these points:
[1]:
==18419==WARNING: invalid path to external symbolizer!
==18419==WARNING: Failed to use and restart external symbolizer!
#0 0x2eac3fd (/data6/liyang/spark-3.2.2-bin-hadoop3.2/liyang/unit_tests_local_engine+0x2eac3fd)
#1 0x30392be (/data6/liyang/spark-3.2.2-bin-hadoop3.2/liyang/unit_tests_local_engine+0x30392be)
#2 0x1404eafc (/data6/liyang/spark-3.2.2-bin-hadoop3.2/liyang/unit_tests_local_engine+0x1404eafc)

[2]:
#0 0x2eac3fd (/data6/liyang/spark-3.2.2-bin-hadoop3.2/liyang/unit_tests_local_engine+0x2eac3fd)
#1 0x7f09a2d0fa0e ([libch.so](http://libch.so/)+0x105f3a0e)
#2 0x7f09d53c96f9 (/lib64/[ld-linux-x86-64.so](http://ld-linux-x86-64.so/).2+0x106f9)

==18419==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'inside_main' at /data1/liyang/cppproject/kyli/ClickHouse/utils/local-engine/tests/gtest_local_engine.cpp:89:6
==18419==ABORTING
```
