### PR TITLE
[CH-369] Fix coredump caused by CHByteArrayChunkedRecordReader 

### DIFF
--- a/utils/local-engine/Storages/ch_parquet/arrow/column_reader.cc
+++ b/utils/local-engine/Storages/ch_parquet/arrow/column_reader.cc
@@ -1928,11 +1928,11 @@ namespace internal {
                                                                 bool read_dictionary) {
             if (read_dictionary) {
                 return std::make_shared<ByteArrayDictionaryRecordReader>(descr, leaf_info, pool);
-            } else if (descr->logical_type()->type() == LogicalType::Type::type::STRING && descr->max_definition_level() == 1) {
-                /// CHByteArrayChunkedRecordReader is only for reading columns whose max_definition_level is 1
-                /// It means CHByteArrayChunkedRecordReader is used when reading column with string type
-                /// but not used when reading column with string type nested in array/map/struct. e.g. array<string>
+            } else if (descr->path()->ToDotVector().size() == 1 && descr->logical_type()->type() == LogicalType::Type::type::STRING) {
+                /// CHByteArrayChunkedRecordReader is only for reading columns with type String and is not nested in complex type
                 /// This fixes issue: https://github.com/Kyligence/ClickHouse/issues/166
+                std::cout << "descr:" << descr->ToString() << std::endl;
+                std::cout << "leaf_info:" << leaf_info << std::endl;
                 return std::make_shared<CHByteArrayChunkedRecordReader>(descr, leaf_info, pool);
             } else {
                 return std::make_shared<ByteArrayChunkedRecordReader>(descr, leaf_info, pool);

--- a/utils/local-engine/Storages/ch_parquet/arrow/column_reader.cc
+++ b/utils/local-engine/Storages/ch_parquet/arrow/column_reader.cc
@@ -1931,8 +1931,6 @@ namespace internal {
             } else if (descr->path()->ToDotVector().size() == 1 && descr->logical_type()->type() == LogicalType::Type::type::STRING) {
                 /// CHByteArrayChunkedRecordReader is only for reading columns with type String and is not nested in complex type
                 /// This fixes issue: https://github.com/Kyligence/ClickHouse/issues/166
-                std::cout << "descr:" << descr->ToString() << std::endl;
-                std::cout << "leaf_info:" << leaf_info << std::endl;
                 return std::make_shared<CHByteArrayChunkedRecordReader>(descr, leaf_info, pool);
             } else {
                 return std::make_shared<ByteArrayChunkedRecordReader>(descr, leaf_info, pool);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix coredump caused by CHByteArrayChunkedRecordReader, closes https://github.com/Kyligence/ClickHouse/issues/369