### PR TITLE
[CH-372] Make block splitting strictly follow the split size during s…

### DIFF
--- a/utils/local-engine/Shuffle/ShuffleSplitter.h
+++ b/utils/local-engine/Shuffle/ShuffleSplitter.h
@@ -31,7 +31,7 @@ class ColumnsBuffer
 {
 public:
     explicit ColumnsBuffer(size_t prefer_buffer_size = 8192);
-    void add(DB::Block & columns, int start, int end);
+    void add(DB::Block & block, int start, int end);
     size_t size() const;
     DB::Block releaseColumns();
     DB::Block getHeader();


### PR DESCRIPTION
Block splitting may not strictly follow the split size, which can result in a relatively large block during shuffle write.

issue: #372 