### PR TITLE
[CH-387] Fix error caused by case-sensitive matching of ORC/Parquet, like Column 'deviceid' is not presented in input data

### DIFF
--- a/utils/local-engine/Common/common.cpp
+++ b/utils/local-engine/Common/common.cpp
@@ -202,7 +202,13 @@ void init(const std::string & plan)
             {
                 settings.set(key, config->getString(settings_path + "." + key));
             }
+
+            /// Fixed settings which must be applied
             settings.set("join_use_nulls", true);
+            settings.set("input_format_orc_allow_missing_columns", true);
+            settings.set("input_format_orc_case_insensitive_column_matching", true);
+            settings.set("input_format_parquet_allow_missing_columns", true);
+            settings.set("input_format_parquet_case_insensitive_column_matching", true);
             LOG_INFO(logger, "Init settings.");
 
             /// Initialize global context


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix error caused by case-sensitive matching of ORC/Parquet, like Column 'deviceid' is not presented in input data

