### PR TITLE
fix size of ColumnBuffer not configurable

### DIFF
--- a/utils/local-engine/Shuffle/NativeSplitter.cpp
+++ b/utils/local-engine/Shuffle/NativeSplitter.cpp
@@ -60,7 +60,7 @@ NativeSplitter::NativeSplitter(Options options_, jobject input_) : options(optio
     partition_buffer.reserve(options.partition_nums);
     for (size_t i = 0; i < options.partition_nums; ++i)
     {
-        partition_buffer.emplace_back(std::make_shared<ColumnsBuffer>());
+        partition_buffer.emplace_back(std::make_shared<ColumnsBuffer>(options.buffer_size));
     }
     CLEAN_JNIENV
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The buffer size of ColumnBuffer is now hard code to 8192, let it be the same as Option.buffer_size.
