### PR TITLE
[405] Eliminate data skew in hash shuffle

### DIFF
--- a/utils/local-engine/Shuffle/SelectorBuilder.cpp
+++ b/utils/local-engine/Shuffle/SelectorBuilder.cpp
@@ -91,14 +91,6 @@ PartitionInfo HashSelectorBuilder::build(DB::Block & block)
     {
         partition_ids.emplace_back(static_cast<UInt64>(hash_column->get64(i) % parts_num));
     }
-    if (result_type->isNullable())
-    {
-        for (size_t i = 0; i < rows; ++i)
-        {
-            if (hash_column->isNullAt(i))
-                partition_ids[i] = 0;
-        }
-    }
     return PartitionInfo::fromSelector(std::move(partition_ids), parts_num);
 }
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Bug Fix

Since `cityHash64` will be null if any argument is null, this could cause data skew. Remove the codes for marking null rows to belong to partition 0, we still keep the result correct. 

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/

close #405 
