### PR TITLE
not change columns to nulllable in expand operator

### DIFF
--- a/utils/local-engine/Operator/ExpandStep.cpp
+++ b/utils/local-engine/Operator/ExpandStep.cpp
@@ -59,21 +59,7 @@ DB::Block ExpandStep::buildOutputHeader(
     for (size_t i = 0; i < input_header.columns(); ++i)
     {
         const auto & old_col = input_header.getByPosition(i);
-        if (i < aggregating_expressions_columns_.size())
-        {
-            // do nothing with the aggregating columns.
-            cols.push_back(old_col);
-            continue;
-        }
-        if (old_col.type->isNullable())
-            cols.push_back(old_col);
-        else
-        {
-            auto null_map = DB::ColumnUInt8::create(0, 0);
-            auto null_col = DB::ColumnNullable::create(old_col.column, std::move(null_map));
-            auto null_type = std::make_shared<DB::DataTypeNullable>(old_col.type);
-            cols.push_back(DB::ColumnWithTypeAndName(null_col, null_type, old_col.name));
-        }
+        cols.push_back(old_col);
     }
 
     // add group id column

--- a/utils/local-engine/Operator/ExpandTransform.cpp
+++ b/utils/local-engine/Operator/ExpandTransform.cpp
@@ -92,14 +92,7 @@ void ExpandTransform::work()
             }
             else
             {
-                if (original_col->isNullable())
-                    cols.push_back(original_col);
-                else
-                {
-                    auto null_map = DB::ColumnUInt8::create(rows, 0);
-                    auto col = DB::ColumnNullable::create(original_col, std::move(null_map));
-                    cols.push_back(std::move(col));
-                }
+                cols.push_back(original_col);
             }
         }
         auto id_col = DB::DataTypeInt64().createColumnConst(input_chunk.getNumRows(), set_id);


### PR DESCRIPTION
<!---
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This pr fix the bug that columns type may be changed in expand operator, which will cause memory problem when serialize and deserialize them.
This close #431 .


