### PR TITLE
[CH-434] convert partition name to lower case

### DIFF
--- a/utils/local-engine/Common/StringUtils.cpp
+++ b/utils/local-engine/Common/StringUtils.cpp
@@ -13,14 +13,24 @@ PartitionValues StringUtils::parsePartitionTablePath(const std::string & file)
         auto position = item.find('=');
         if (position != std::string::npos)
         {
-            result.emplace_back(PartitionValue(item.substr(0,position), item.substr(position+1)));
+            result.emplace_back(PartitionValue(toLowerCase(item.substr(0,position)), item.substr(position+1)));
         }
     }
     return result;
 }
+
 bool StringUtils::isNullPartitionValue(const std::string & value)
 {
     return value == "__HIVE_DEFAULT_PARTITION__";
+}
+
+std::string StringUtils::toLowerCase(const std::string & value)
+{
+    std::string res = value;
+    for (size_t i = 0; i < value.size(); i++) {
+        res[i] = tolower(value[i]);
+    }
+    return res;
 }
 }
 

--- a/utils/local-engine/Common/StringUtils.h
+++ b/utils/local-engine/Common/StringUtils.h
@@ -12,5 +12,6 @@ class StringUtils
 public:
     static PartitionValues parsePartitionTablePath(const std::string & file);
     static bool isNullPartitionValue(const std::string & value);
+    static std::string toLowerCase(const std::string & value);
 };
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
This pr converts partition names get from hdfs path to lower case, as spark paritiions are in lower case.
It fix #434 .