### PR TITLE
[GLUTEN-1914] Allow nullable complex type when convert arrow column to ch column. 

### DIFF
--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -680,9 +680,7 @@ static ColumnWithTypeAndName readColumnFromArrowColumn(
     DataTypePtr type_hint = nullptr,
     bool is_map_nested = false)
 {
-    if (!is_nullable && (arrow_column->null_count() || (type_hint && type_hint->isNullable())) && arrow_column->type()->id() != arrow::Type::LIST
-        && arrow_column->type()->id() != arrow::Type::MAP && arrow_column->type()->id() != arrow::Type::STRUCT &&
-        arrow_column->type()->id() != arrow::Type::DICTIONARY)
+    if (!is_nullable && (arrow_column->null_count() || (type_hint && type_hint->isNullable())) && arrow_column->type()->id() != arrow::Type::DICTIONARY)
     {
         DataTypePtr nested_type_hint;
         if (type_hint)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Close https://github.com/oap-project/gluten/issues/1914 


原来的实现：当将arrow column转化为ch column时，如果arrow type是负责类型(list/map/struct), 则不抽取arrow column的null map, 因为ch中复杂类型都是非nullable的。

现在的实现：为了保持与gluten兼容，即允许复杂类型为nullable, 修改代码，使得arrow type为复杂类型时，依然抽取null map和data column, 构成对应ch的nullable column 
