### PR TITLE
Allow nullable complex types when writing into parquet/orc

### DIFF
--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -208,7 +208,7 @@ namespace DB
         const String & column_name,
         ColumnPtr & column,
         const DataTypePtr & column_type,
-        const PaddedPODArray<UInt8> *,
+        const PaddedPODArray<UInt8> *null_bytemap,
         arrow::ArrayBuilder * array_builder,
         String format_name,
         size_t start,
@@ -228,12 +228,32 @@ namespace DB
 
         for (size_t array_idx = start; array_idx < end; ++array_idx)
         {
-            /// Start new array.
-            components_status = builder.Append();
-            checkStatus(components_status, nested_column->getName(), format_name);
+            if (!null_bytemap || !(*null_bytemap)[array_idx])
+            {
+                /// Start new array.
+                components_status = builder.Append();
+                checkStatus(components_status, nested_column->getName(), format_name);
 
-            /// Pass null null_map, because fillArrowArray will decide whether nested_type is nullable, if nullable, it will create a new null_map from nested_column
-            fillArrowArray(column_name, nested_column, nested_type, nullptr, value_builder, format_name, offsets[array_idx - 1], offsets[array_idx], output_string_as_string, output_fixed_string_as_fixed_byte_array, dictionary_values);
+                /// Pass null null_map, because fillArrowArray will decide whether nested_type is nullable, if nullable, it will create a new null_map from nested_column
+                fillArrowArray(
+                    column_name,
+                    nested_column,
+                    nested_type,
+                    nullptr,
+                    value_builder,
+                    format_name,
+                    offsets[array_idx - 1],
+                    offsets[array_idx],
+                    output_string_as_string,
+                    output_fixed_string_as_fixed_byte_array,
+                    dictionary_values);
+            }
+            else
+            {
+                /// Append null array.
+                components_status = builder.AppendNull();
+                checkStatus(components_status, nested_column->getName(), format_name);
+            }
         }
     }
 
@@ -273,7 +293,7 @@ namespace DB
 
         for (size_t i = start; i != end; ++i)
         {
-            auto status = builder.Append();
+            auto status = builder.Append(null_bytemap ? !(*null_bytemap)[i] : true);
             checkStatus(status, column->getName(), format_name);
         }
     }


### PR DESCRIPTION

### Changelog category (leave one):
- Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow nullable complex types when writing into parquet/orc

