### PR TITLE
[GLUTEN-2582][CH]Bug fix for crash problem in array<struct> select

### DIFF
--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1176,7 +1176,11 @@ ColumnPtr FunctionArrayElement::perform(const ColumnsWithTypeAndName & arguments
 {
     ColumnPtr res;
     if ((res = executeTuple(arguments, input_rows_count)))
+    {
+        if (builder)
+            builder.initSink(input_rows_count);
         return res;
+    }
     else if (!isColumnConst(*arguments[1].column))
     {
         if (!((res = executeArgument<UInt8>(arguments, result_type, builder, input_rows_count))


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
Bug fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Bug fix problem described in: https://github.com/oap-project/gluten/issues/2582

While use array<struct> as filter, like `select * from table where data[0].a = 1`,  it will use `arrayElement` function to do its filter action,  and go to #perform#executeTuple at arrayElement.cpp, which will return directly, and not init sink to builder.

and the `sink_null_map_holder` in builder not init, still is a nullptr, the left procedure will transform on this nullptr, and cause crash.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
