### PR TITLE
[GLUTEN-3137] Skip map field with complex key type when reading schema from orc files

### DIFF
--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -157,6 +157,12 @@ static DataTypePtr parseORCType(const orc::Type * orc_type, bool skip_columns_wi
             if (skipped)
                 return {};
 
+            if (!DataTypeMap::checkKeyType(key_type) && skip_columns_with_unsupported_types)
+            {
+                skipped = true;
+                return {};
+            }
+
             DataTypePtr value_type = parseORCType(orc_type->getSubtype(1), skip_columns_with_unsupported_types, skipped);
             if (skipped)
                 return {};


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Skip map field with complex key type when reading schema from orc files. This change could avoid failed uts under package `org.apache.spark.sql.execution.datasources.orc`
