### PR TITLE
Optimize array element function when input is array(map)/array(array(string))/array(array(number))

### DIFF
--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1,23 +1,24 @@
-#include <Functions/IFunction.h>
-#include <Functions/FunctionFactory.h>
-#include <Functions/FunctionHelpers.h>
-#include <Functions/castTypeToEither.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnMap.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnTuple.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/ColumnNumbers.h>
+#include <Core/Field.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
-#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypesNumber.h>
-#include <Core/ColumnNumbers.h>
-#include <Columns/ColumnArray.h>
-#include <Core/Field.h>
-#include <Columns/ColumnNullable.h>
-#include <Columns/ColumnsNumber.h>
-#include <Columns/ColumnString.h>
-#include <Columns/ColumnFixedString.h>
-#include <Columns/ColumnTuple.h>
-#include <Columns/ColumnMap.h>
-#include <Common/typeid_cast.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Functions/castTypeToEither.h>
+#include <Interpreters/Context.h>
 #include <Common/assert_cast.h>
+#include <Common/typeid_cast.h>
 
 
 namespace DB
@@ -43,7 +44,9 @@ class FunctionArrayElement : public IFunction
 {
 public:
     static constexpr auto name = "arrayElement";
-    static FunctionPtr create(ContextPtr context);
+    static FunctionPtr create(ContextPtr context_);
+
+    explicit FunctionArrayElement(ContextPtr context_) : context(context_) { }
 
     String getName() const override;
 
@@ -65,10 +68,29 @@ private:
     template <typename IndexType, typename DataType>
     static ColumnPtr executeNumber(const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder);
 
+    /// Optimize arrayElement when first argument has type Array(T) or Array(Nullable(T)) in which T is number type
+    template <typename DataType>
+    static ColumnPtr
+    executeArrayNumberConst(const ColumnsWithTypeAndName & arguments, const Field & index, ArrayImpl::NullMapBuilder & builder);
+
+    /// Optimize arrayElement when first argument has type Array(T) or Array(Nullable(T)) in which T is number type
+    template <typename IndexType, typename DataType>
+    static ColumnPtr executeArrayNumber(
+        const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder);
+
     static ColumnPtr executeStringConst(const ColumnsWithTypeAndName & arguments, const Field & index, ArrayImpl::NullMapBuilder & builder);
 
     template <typename IndexType>
     static ColumnPtr executeString(const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder);
+
+    /// Optimize arrayElement when first argument has type Array(String) or Array(Nullable(String))
+    static ColumnPtr
+    executeArrayStringConst(const ColumnsWithTypeAndName & arguments, const Field & index, ArrayImpl::NullMapBuilder & builder);
+
+    /// Optimize arrayElement when first argument has type Array(String) or Array(Nullable(String))
+    template <typename IndexType>
+    static ColumnPtr executeArrayString(
+        const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder);
 
     static ColumnPtr executeGenericConst(const ColumnsWithTypeAndName & arguments, const Field & index, ArrayImpl::NullMapBuilder & builder);
 
@@ -87,6 +109,10 @@ private:
     /** For a tuple array, the function is evaluated component-wise for each element of the tuple.
       */
     ColumnPtr executeTuple(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const;
+
+    /** For a map array, the function is evaluated component-wise for its key and value
+      */
+    ColumnPtr executeMap2(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const;
 
     /** For a map the function finds the matched value for a key.
      *  Currently implemented just as linear search in array.
@@ -120,6 +146,8 @@ private:
     static void executeMatchConstKeyToIndex(
         size_t num_rows, size_t num_values,
         PaddedPODArray<UInt64> & matched_idxs, const Matcher & matcher);
+
+    ContextPtr context;
 };
 
 
@@ -255,6 +283,361 @@ struct ArrayElementNumImpl
         }
     }
 };
+
+
+template <typename T>
+struct ArrayElementArrayNumImpl
+{
+    /** Implementation for constant index.
+      * If negative = false - index is from beginning of array, started from 0.
+      * If negative = true - index is from end of array, started from 0.
+      * nullable_number is true when process input with type Array(Array(Nullable(T)))
+      */
+    template <bool negative, bool nullable_number>
+    static void vectorConst(
+        const PaddedPODArray<T> & data,
+        const ColumnArray::Offsets & offsets,
+        const ColumnArray::Offsets & nested_offsets,
+        const NullMap * number_null_map,
+        const ColumnArray::Offset index,
+        PaddedPODArray<T> & result_data,
+        ColumnArray::Offsets & result_offsets,
+        NullMap * result_number_null_map,
+        ArrayImpl::NullMapBuilder & builder)
+    {
+        size_t size = offsets.size();
+
+        /// First calculate the size of result_data or result_number_null_map
+        size_t result_data_size = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+            if (index < array_size)
+            {
+                size_t j = !negative ? (offsets[i - 1] + index) : (offsets[i] - index - 1);
+                ColumnArray::Offset nested_array_size = nested_offsets[j] - nested_offsets[j-1];
+                result_data_size += nested_array_size;
+            }
+        }
+
+        /// Allocate enough memory in advance
+        result_data.resize(result_data_size);
+        result_offsets.resize(size);
+        if constexpr (nullable_number)
+            result_number_null_map->resize(result_data_size);
+
+        ColumnArray::Offset current_offset = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+            if (index < array_size)
+            {
+                size_t j = !negative ? (offsets[i - 1] + index) : (offsets[i] - index - 1);
+                if (builder)
+                    builder.update(j);
+
+                ColumnArray::Offset nested_array_size = nested_offsets[j] - nested_offsets[j-1];
+                ColumnArray::Offset nested_array_pos = nested_offsets[j-1];
+                for (size_t k = 0; k < nested_array_size; ++k)
+                {
+                    result_data[current_offset + k] = data[nested_array_pos + k];
+                    if constexpr (nullable_number)
+                        (*result_number_null_map)[current_offset + k] = (*number_null_map)[nested_array_pos + k];
+                }
+
+                current_offset += nested_array_size;
+            }
+            else
+            {
+                /// Empty Array(T), no need to copy anything
+                if (builder)
+                    builder.update();
+            }
+
+            result_offsets[i] = current_offset;
+        }
+    }
+
+    /** Implementation for non-constant index.
+      */
+    template <typename TIndex, bool nullable_number>
+    static void vector(
+        const PaddedPODArray<T> & data,
+        const ColumnArray::Offsets & offsets,
+        const ColumnArray::Offsets & nested_offsets,
+        const NullMap * number_null_map,
+        const PaddedPODArray<TIndex> & indices,
+        PaddedPODArray<T> & result_data,
+        ColumnArray::Offsets & result_offsets,
+        NullMap * result_number_null_map,
+        ArrayImpl::NullMapBuilder & builder)
+    {
+        size_t size = offsets.size();
+
+        /// First calculate the size of result_data or result_number_null_map
+        size_t result_data_size = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+            TIndex index = indices[i];
+            if (index > 0 && static_cast<size_t>(index) <= array_size)
+            {
+                size_t j = offsets[i - 1] + index - 1;
+                ColumnArray::Offset nested_array_size = nested_offsets[j] - nested_offsets[j - 1];
+                result_data_size += nested_array_size;
+            }
+            else if (index < 0 && -static_cast<size_t>(index) <= array_size)
+            {
+                size_t j = offsets[i] + index;
+                ColumnArray::Offset nested_array_size = nested_offsets[j] - nested_offsets[j - 1];
+                result_data_size += nested_array_size;
+            }
+        }
+
+        /// Allocate enough memory in advance
+        result_data.resize(result_data_size);
+        result_offsets.resize(size);
+        if constexpr (nullable_number)
+            result_number_null_map->resize(result_data_size);
+
+        ColumnArray::Offset current_offset = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i - 1];
+
+            TIndex index = indices[i];
+            if (index > 0 && static_cast<size_t>(index) <= array_size)
+            {
+                size_t j = offsets[i - 1] + index - 1;
+                if (builder)
+                    builder.update(j);
+
+                ColumnArray::Offset nested_array_size = nested_offsets[j] - nested_offsets[j-1];
+                ColumnArray::Offset nested_array_pos = nested_offsets[j-1];
+                for (size_t k = 0; k < nested_array_size; ++k)
+                {
+                    result_data[current_offset + k] = data[nested_array_pos + k];
+                    if constexpr (nullable_number)
+                        (*result_number_null_map)[current_offset + k] = (*number_null_map)[nested_array_pos + k];
+                }
+
+                current_offset += nested_array_size;
+            }
+            else if (index < 0 && -static_cast<size_t>(index) <= array_size)
+            {
+                size_t j = offsets[i] + index;
+                if (builder)
+                    builder.update(j);
+
+                ColumnArray::Offset nested_array_size = nested_offsets[j] - nested_offsets[j - 1];
+                ColumnArray::Offset nested_array_pos = nested_offsets[j-1];
+                for (size_t k = 0; k < nested_array_size; ++k)
+                {
+                    result_data[current_offset + k] = data[nested_array_pos + k];
+                    if constexpr (nullable_number)
+                        (*result_number_null_map)[current_offset + k] = (*number_null_map)[nested_array_pos + k];
+                }
+
+                current_offset += nested_array_size;
+            }
+            else
+            {
+                /// Empty Array(T), no need to copy anything
+                if (builder)
+                    builder.update();
+            }
+
+            result_offsets[i] = current_offset;
+        }
+    }
+};
+
+struct ArrayElementArrayStringImpl
+{
+    /// nullable_string is true when process input with type Array(Array(Nullable(String)))
+    template <bool negative, bool nullable_string>
+    static void vectorConst(
+        const ColumnString::Chars & data,
+        const ColumnArray::Offsets & offsets,
+        const ColumnArray::Offsets & nested_offsets,
+        const ColumnString::Offsets & string_offsets,
+        const NullMap * string_null_map,
+        const ColumnArray::Offset index,
+        ColumnString::Chars & result_data,
+        ColumnArray::Offsets & result_offsets,
+        ColumnArray::Offsets & result_string_offsets,
+        NullMap * result_string_null_map,
+        ArrayImpl::NullMapBuilder & builder)
+    {
+        size_t size = offsets.size();
+
+        /// First calculate size of result_data(total count of strings) and result_string_offsets(total size of strings)
+        size_t result_data_size = 0;
+        size_t result_strings_size = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+            if (index < array_size)
+            {
+                size_t adjusted_index = !negative ? index : (array_size - index - 1);
+                size_t j = offsets[i - 1] + adjusted_index;
+
+                auto nested_array_start = nested_offsets[j - 1];
+                auto nested_array_size = nested_offsets[j] - nested_array_start;
+
+                result_data_size += string_offsets[nested_array_start + nested_array_size - 1] - string_offsets[nested_array_start - 1];
+                result_strings_size += nested_array_size;
+            }
+        }
+
+        /// Allocate enough memory in advance
+        result_data.resize(result_data_size);
+        result_offsets.resize(size);
+        result_string_offsets.reserve(result_strings_size);
+        if constexpr (nullable_string)
+            result_string_null_map->reserve(result_strings_size);
+
+        ColumnArray::Offset current_offset = 0;
+        ColumnArray::Offset current_string_offset = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+
+            if (index < array_size)
+            {
+                size_t adjusted_index = !negative ? index : (array_size - index - 1);
+                size_t j = offsets[i - 1] + adjusted_index;
+                if (builder)
+                    builder.update(j);
+
+                auto nested_array_start = nested_offsets[j - 1];
+                auto nested_array_size = nested_offsets[j] - nested_array_start;
+
+                /// For each String in Array(String), append it to result_data and update result_offsets and result_string_offsets
+                for (size_t k = 0; k < nested_array_size; ++k)
+                {
+                    auto string_start = string_offsets[nested_array_start + k - 1];
+                    auto string_size = string_offsets[nested_array_start + k] - string_start;
+                    memcpySmallAllowReadWriteOverflow15(&result_data[current_string_offset], &data[string_start], string_size);
+                    current_string_offset += string_size;
+                    result_string_offsets.push_back(current_string_offset);
+
+                    if constexpr (nullable_string)
+                        result_string_null_map->push_back((*string_null_map)[nested_array_start + k]);
+                }
+                current_offset += nested_array_size;
+            }
+            else
+            {
+                /// Insert empty Array(String) or Array(Nullable(String)), no need to copy anything
+                if (builder)
+                    builder.update();
+            }
+            result_offsets[i] = current_offset;
+        }
+    }
+
+    /** Implementation for non-constant index.
+      */
+    template <typename TIndex, bool nullable_string>
+    static void vector(
+        const ColumnString::Chars & data,
+        const ColumnArray::Offsets & offsets,
+        const ColumnArray::Offsets & nested_offsets,
+        const ColumnString::Offsets & string_offsets,
+        const NullMap * string_null_map,
+        const PaddedPODArray<TIndex> & indices,
+        ColumnString::Chars & result_data,
+        ColumnArray::Offsets & result_offsets,
+        ColumnArray::Offsets & result_string_offsets,
+        NullMap * result_string_null_map,
+        ArrayImpl::NullMapBuilder & builder)
+    {
+        size_t size = offsets.size();
+
+        /// First calculate size of result_data(total count of strings) and result_string_offsets(total size of strings)
+        size_t result_data_size = 0;
+        size_t result_strings_size = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+            size_t adjusted_index;    /// index in array from zero
+            TIndex index = indices[i];
+            if (index > 0 && static_cast<size_t>(index) <= array_size)
+                adjusted_index = index - 1;
+            else if (index < 0 && -static_cast<size_t>(index) <= array_size)
+                adjusted_index = array_size + index;
+            else
+                adjusted_index = array_size;    /// means no element should be taken
+
+            if (adjusted_index < array_size)
+            {
+                size_t j = offsets[i - 1] + adjusted_index;
+
+                auto nested_array_start = nested_offsets[j - 1];
+                auto nested_array_size = nested_offsets[j] - nested_array_start;
+
+                result_data_size += string_offsets[nested_array_start + nested_array_size - 1] - string_offsets[nested_array_start - 1];
+                result_strings_size += nested_array_size;
+            }
+        }
+
+        /// Allocate enough memory in advance
+        result_data.resize(result_data_size);
+        result_offsets.resize(size);
+        result_string_offsets.reserve(result_strings_size);
+        if constexpr (nullable_string)
+            result_string_null_map->reserve(result_strings_size);
+
+        ColumnArray::Offset current_offset = 0;
+        ColumnArray::Offset current_string_offset = 0;
+        for (size_t i = 0; i < size; ++i)
+        {
+            size_t array_size = offsets[i] - offsets[i-1];
+            size_t adjusted_index;    /// index in array from zero
+
+            TIndex index = indices[i];
+            if (index > 0 && static_cast<size_t>(index) <= array_size)
+                adjusted_index = index - 1;
+            else if (index < 0 && -static_cast<size_t>(index) <= array_size)
+                adjusted_index = array_size + index;
+            else
+                adjusted_index = array_size;    /// means no element should be taken
+
+            if (adjusted_index < array_size)
+            {
+                size_t j = current_offset + adjusted_index;
+                if (builder)
+                    builder.update(j);
+
+                auto nested_array_start = nested_offsets[j - 1];
+                auto nested_array_size = nested_offsets[j] - nested_array_start;
+
+                /// For each String in Array(String), append it to result_data and update result_offsets and result_string_offsets
+                for (size_t k = 0; k < nested_array_size; ++k)
+                {
+                    auto string_start = string_offsets[nested_array_start + k - 1];
+                    auto string_size = string_offsets[nested_array_start + k] - string_start;
+                    memcpySmallAllowReadWriteOverflow15(&result_data[current_string_offset], &data[string_start], string_size);
+                    current_string_offset += string_size;
+                    result_string_offsets.push_back(current_string_offset);
+
+                    if constexpr (nullable_string)
+                        result_string_null_map->push_back((*string_null_map)[nested_array_start + k]);
+                }
+                current_offset += nested_array_size;
+            }
+            else
+            {
+                /// Insert empty Array(String), no need to copy anything
+                if (builder)
+                    builder.update();
+            }
+            result_offsets[i] = current_offset;
+        }
+    }
+};
+
 
 struct ArrayElementStringImpl
 {
@@ -453,9 +836,9 @@ struct ArrayElementGenericImpl
 }
 
 
-FunctionPtr FunctionArrayElement::create(ContextPtr)
+FunctionPtr FunctionArrayElement::create(ContextPtr context_)
 {
-    return std::make_shared<FunctionArrayElement>();
+    return std::make_shared<FunctionArrayElement>(context_);
 }
 
 
@@ -571,6 +954,277 @@ FunctionArrayElement::executeStringConst(const ColumnsWithTypeAndName & argument
     return col_res;
 }
 
+ColumnPtr FunctionArrayElement::executeArrayStringConst(
+    const ColumnsWithTypeAndName & arguments, const Field & index, ArrayImpl::NullMapBuilder & builder)
+{
+    const ColumnArray * col_array = checkAndGetColumn<ColumnArray>(arguments[0].column.get());
+    if (!col_array)
+        return nullptr;
+
+    const ColumnArray * col_nested_array = checkAndGetColumn<ColumnArray>(&col_array->getData());
+    if (!col_nested_array)
+        return nullptr;
+
+    const ColumnString * col_nested_elem = nullptr;
+    const auto * col_nullable = checkAndGetColumn<ColumnNullable>(col_nested_array->getDataPtr().get());
+    if (!col_nullable)
+        col_nested_elem = checkAndGetColumn<ColumnString>(&col_nested_array->getData());
+    else
+        col_nested_elem = checkAndGetColumn<ColumnString>(col_nullable->getNestedColumnPtr().get());
+
+    if (!col_nested_elem)
+        return nullptr;
+
+    const auto * string_null_map = col_nullable ? &col_nullable->getNullMapColumn() : nullptr;
+    auto res_string = ColumnString::create();
+    auto res_offsets = ColumnArray::ColumnOffsets::create();
+    auto res_string_null_map = col_nullable ? ColumnUInt8::create() : nullptr;
+    if (index.getType() == Field::Types::UInt64
+        || (index.getType() == Field::Types::Int64 && index.get<Int64>() >= 0))
+    {
+        if (col_nullable)
+            ArrayElementArrayStringImpl::vectorConst<false, true>(
+                col_nested_elem->getChars(),
+                col_array->getOffsets(),
+                col_nested_array->getOffsets(),
+                col_nested_elem->getOffsets(),
+                &string_null_map->getData(),
+                index.get<UInt64>() - 1,
+                res_string->getChars(),
+                res_offsets->getData(),
+                res_string->getOffsets(),
+                &res_string_null_map->getData(),
+                builder);
+        else
+            ArrayElementArrayStringImpl::vectorConst<false, false>(
+                col_nested_elem->getChars(),
+                col_array->getOffsets(),
+                col_nested_array->getOffsets(),
+                col_nested_elem->getOffsets(),
+                nullptr,
+                index.get<UInt64>() - 1,
+                res_string->getChars(),
+                res_offsets->getData(),
+                res_string->getOffsets(),
+                nullptr,
+                builder);
+    }
+    else if (index.getType() == Field::Types::Int64)
+    {
+        if (col_nullable)
+            ArrayElementArrayStringImpl::vectorConst<true, true>(
+                col_nested_elem->getChars(),
+                col_array->getOffsets(),
+                col_nested_array->getOffsets(),
+                col_nested_elem->getOffsets(),
+                &string_null_map->getData(),
+                -(UInt64(index.get<Int64>()) + 1),
+                res_string->getChars(),
+                res_offsets->getData(),
+                res_string->getOffsets(),
+                &res_string_null_map->getData(),
+                builder);
+        else
+            ArrayElementArrayStringImpl::vectorConst<true, false>(
+                col_nested_elem->getChars(),
+                col_array->getOffsets(),
+                col_nested_array->getOffsets(),
+                col_nested_elem->getOffsets(),
+                nullptr,
+                -(UInt64(index.get<Int64>()) + 1),
+                res_string->getChars(),
+                res_offsets->getData(),
+                res_string->getOffsets(),
+                nullptr,
+                builder);
+    }
+    else
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Illegal type of array index");
+
+    if (col_nullable)
+        return ColumnArray::create(ColumnNullable::create(std::move(res_string), std::move(res_string_null_map)), std::move(res_offsets));
+    else
+        return ColumnArray::create(std::move(res_string), std::move(res_offsets));
+}
+
+template <typename DataType>
+ColumnPtr FunctionArrayElement::executeArrayNumberConst(
+    const ColumnsWithTypeAndName & arguments, const Field & index, ArrayImpl::NullMapBuilder & builder)
+{
+    const ColumnArray * col_array = checkAndGetColumn<ColumnArray>(arguments[0].column.get());
+    if (!col_array)
+        return nullptr;
+
+    const ColumnArray * col_nested_array = checkAndGetColumn<ColumnArray>(col_array->getDataPtr().get());
+    if (!col_nested_array)
+        return nullptr;
+
+    const ColumnVector<DataType> * col_nested_elem = nullptr;
+    const auto * col_nullable = checkAndGetColumn<ColumnNullable>(col_nested_array->getDataPtr().get());
+    if (!col_nullable)
+        col_nested_elem = checkAndGetColumn<ColumnVector<DataType>>(&col_nested_array->getData());
+    else
+        col_nested_elem = checkAndGetColumn<ColumnVector<DataType>>(col_nullable->getNestedColumnPtr().get());
+
+    if (!col_nested_elem)
+        return nullptr;
+
+    const auto * null_map = col_nullable ? &col_nullable->getNullMapColumn() : nullptr;
+    auto res_data = ColumnVector<DataType>::create();
+    auto res_offsets = ColumnArray::ColumnOffsets::create();
+    auto res_null_map = col_nullable ? ColumnUInt8::create() : nullptr;
+    if (index.getType() == Field::Types::UInt64 || (index.getType() == Field::Types::Int64 && index.get<Int64>() >= 0))
+    {
+        if (col_nullable)
+            ArrayElementArrayNumImpl<DataType>::template vectorConst<false, true>(
+                col_nested_elem->getData(),
+                col_array->getOffsets(),
+                col_nested_array->getOffsets(),
+                &null_map->getData(),
+                index.get<UInt64>() - 1,
+                res_data->getData(),
+                res_offsets->getData(),
+                &res_null_map->getData(),
+                builder);
+        else
+            ArrayElementArrayNumImpl<DataType>::template vectorConst<false, false>(
+                col_nested_elem->getData(),
+                col_array->getOffsets(),
+                col_nested_array->getOffsets(),
+                nullptr,
+                index.get<UInt64>() - 1,
+                res_data->getData(),
+                res_offsets->getData(),
+                nullptr,
+                builder);
+    }
+    else if (index.getType() == Field::Types::Int64)
+    {
+        auto value = index.safeGet<Int64>();
+        if (value >= 0)
+        {
+            if (col_nullable)
+                ArrayElementArrayNumImpl<DataType>::template vectorConst<false, true>(
+                    col_nested_elem->getData(),
+                    col_array->getOffsets(),
+                    col_nested_array->getOffsets(),
+                    &null_map->getData(),
+                    index.get<UInt64>() - 1,
+                    res_data->getData(),
+                    res_offsets->getData(),
+                    &res_null_map->getData(),
+                    builder);
+            else
+                ArrayElementArrayNumImpl<DataType>::template vectorConst<false, false>(
+                    col_nested_elem->getData(),
+                    col_array->getOffsets(),
+                    col_nested_array->getOffsets(),
+                    nullptr,
+                    index.get<UInt64>() - 1,
+                    res_data->getData(),
+                    res_offsets->getData(),
+                    nullptr,
+                    builder);
+        }
+        else
+        {
+            /// Cast to UInt64 before negation allows to avoid undefined behaviour for negation of the most negative number.
+            /// NOTE: this would be undefined behaviour in C++ sense, but nevertheless, compiler cannot see it on user provided data,
+            /// and generates the code that we want on supported CPU architectures (overflow in sense of two's complement arithmetic).
+            /// This is only needed to avoid UBSan report.
+
+            /// Negative array indices work this way:
+            /// arr[-1] is the element at offset 0 from the last
+            /// arr[-2] is the element at offset 1 from the last and so on.
+            if (col_nullable)
+                ArrayElementArrayNumImpl<DataType>::template vectorConst<true, true>(
+                    col_nested_elem->getData(),
+                    col_array->getOffsets(),
+                    col_nested_array->getOffsets(),
+                    &null_map->getData(),
+                    index.get<UInt64>() - 1,
+                    res_data->getData(),
+                    res_offsets->getData(),
+                    &res_null_map->getData(),
+                    builder);
+            else
+                ArrayElementArrayNumImpl<DataType>::template vectorConst<true, false>(
+                    col_nested_elem->getData(),
+                    col_array->getOffsets(),
+                    col_nested_array->getOffsets(),
+                    nullptr,
+                    index.get<UInt64>() - 1,
+                    res_data->getData(),
+                    res_offsets->getData(),
+                    nullptr,
+                    builder);
+        }
+    }
+    else
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Illegal type of array index");
+
+    if (col_nullable)
+        return ColumnArray::create(ColumnNullable::create(std::move(res_data), std::move(res_null_map)), std::move(res_offsets));
+    else
+        return ColumnArray::create(std::move(res_data), std::move(res_offsets));
+}
+
+template <typename IndexType, typename DataType>
+ColumnPtr FunctionArrayElement::executeArrayNumber(
+    const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder)
+{
+    const ColumnArray * col_array = checkAndGetColumn<ColumnArray>(arguments[0].column.get());
+    if (!col_array)
+        return nullptr;
+
+    const ColumnArray * col_nested_array = checkAndGetColumn<ColumnArray>(col_array->getDataPtr().get());
+    if (!col_nested_array)
+        return nullptr;
+
+    const ColumnVector<DataType> * col_nested_elem = nullptr;
+    const auto * col_nullable = checkAndGetColumn<ColumnNullable>(col_nested_array->getDataPtr().get());
+    if (!col_nullable)
+        col_nested_elem = checkAndGetColumn<ColumnVector<DataType>>(&col_nested_array->getData());
+    else
+        col_nested_elem = checkAndGetColumn<ColumnVector<DataType>>(col_nullable->getNestedColumnPtr().get());
+
+    if (!col_nested_elem)
+        return nullptr;
+
+    const auto * null_map = col_nullable ? &col_nullable->getNullMapColumn() : nullptr;
+    auto res_data = ColumnVector<DataType>::create();
+    auto res_offsets = ColumnArray::ColumnOffsets::create();
+    auto res_null_map = col_nullable ? ColumnUInt8::create() : nullptr;
+
+    if (col_nullable)
+        ArrayElementArrayNumImpl<DataType>::template vector<IndexType, true>(
+            col_nested_elem->getData(),
+            col_array->getOffsets(),
+            col_nested_array->getOffsets(),
+            &null_map->getData(),
+            indices,
+            res_data->getData(),
+            res_offsets->getData(),
+            &res_null_map->getData(),
+            builder);
+    else
+        ArrayElementArrayNumImpl<DataType>::template vector<IndexType, false>(
+            col_nested_elem->getData(),
+            col_array->getOffsets(),
+            col_nested_array->getOffsets(),
+            nullptr,
+            indices,
+            res_data->getData(),
+            res_offsets->getData(),
+            nullptr,
+            builder);
+
+    if (col_nullable)
+        return ColumnArray::create(ColumnNullable::create(std::move(res_data), std::move(res_null_map)), std::move(res_offsets));
+    else
+        return ColumnArray::create(std::move(res_data), std::move(res_offsets));
+}
+
 template <typename IndexType>
 ColumnPtr FunctionArrayElement::executeString(
     const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder)
@@ -596,6 +1250,66 @@ ColumnPtr FunctionArrayElement::executeString(
         builder);
 
     return col_res;
+}
+
+template <typename IndexType>
+ColumnPtr FunctionArrayElement::executeArrayString(
+    const ColumnsWithTypeAndName & arguments, const PaddedPODArray<IndexType> & indices, ArrayImpl::NullMapBuilder & builder)
+{
+    const ColumnArray * col_array = checkAndGetColumn<ColumnArray>(arguments[0].column.get());
+    if (!col_array)
+        return nullptr;
+
+    const ColumnArray * col_nested_array = checkAndGetColumn<ColumnArray>(&col_array->getData());
+    if (!col_nested_array)
+        return nullptr;
+
+    const ColumnString * col_nested_elem = nullptr;
+    const auto * col_nullable = checkAndGetColumn<ColumnNullable>(col_nested_array->getDataPtr().get());
+    if (!col_nullable)
+        col_nested_elem = checkAndGetColumn<ColumnString>(&col_nested_array->getData());
+    else
+        col_nested_elem = checkAndGetColumn<ColumnString>(col_nullable->getNestedColumnPtr().get());
+
+    if (!col_nested_elem)
+        return nullptr;
+
+    const auto * string_null_map = col_nullable ? &col_nullable->getNullMapColumn() : nullptr;
+    auto res_string = ColumnString::create();
+    auto res_offsets = ColumnArray::ColumnOffsets::create();
+    auto res_string_null_map = col_nullable ? ColumnUInt8::create() : nullptr;
+
+    if (col_nullable)
+        ArrayElementArrayStringImpl::vector<IndexType, true>(
+            col_nested_elem->getChars(),
+            col_array->getOffsets(),
+            col_nested_array->getOffsets(),
+            col_nested_elem->getOffsets(),
+            &string_null_map->getData(),
+            indices,
+            res_string->getChars(),
+            res_offsets->getData(),
+            res_string->getOffsets(),
+            &res_string_null_map->getData(),
+            builder);
+    else
+        ArrayElementArrayStringImpl::vector<IndexType, false>(
+            col_nested_elem->getChars(),
+            col_array->getOffsets(),
+            col_nested_array->getOffsets(),
+            col_nested_elem->getOffsets(),
+            nullptr,
+            indices,
+            res_string->getChars(),
+            res_offsets->getData(),
+            res_string->getOffsets(),
+            nullptr,
+            builder);
+
+    if (col_nullable)
+        return ColumnArray::create(ColumnNullable::create(std::move(res_string), std::move(res_string_null_map)), std::move(res_offsets));
+    else
+        return ColumnArray::create(std::move(res_string), std::move(res_offsets));
 }
 
 ColumnPtr FunctionArrayElement::executeGenericConst(
@@ -698,33 +1412,103 @@ ColumnPtr FunctionArrayElement::executeArgument(
 
     ColumnPtr res;
     if (!((res = executeNumber<IndexType, UInt8>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, UInt16>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, UInt32>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, UInt64>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, Int8>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, Int16>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, Int32>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, Int64>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, Float32>(arguments, index_data, builder))
-        || (res = executeNumber<IndexType, Float64>(arguments, index_data, builder))
-        || (res = executeConst<IndexType>(arguments, result_type, index_data, builder, input_rows_count))
-        || (res = executeString<IndexType>(arguments, index_data, builder))
-        || (res = executeGeneric<IndexType>(arguments, index_data, builder))))
+          || (res = executeNumber<IndexType, UInt16>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, UInt32>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, UInt64>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, Int8>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, Int16>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, Int32>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, Int64>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, Float32>(arguments, index_data, builder))
+          || (res = executeNumber<IndexType, Float64>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, UInt8>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, UInt16>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, UInt32>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, UInt64>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, Int8>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, Int16>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, Int32>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, Int64>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, Float32>(arguments, index_data, builder))
+          || (res = executeArrayNumber<IndexType, Float64>(arguments, index_data, builder))
+          || (res = executeConst<IndexType>(arguments, result_type, index_data, builder, input_rows_count))
+          || (res = executeString<IndexType>(arguments, index_data, builder))
+          || (res = executeArrayString<IndexType>(arguments, index_data, builder))
+          || (res = executeGeneric<IndexType>(arguments, index_data, builder))))
         throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}",
                     arguments[0].column->getName(), getName());
 
     return res;
 }
 
+ColumnPtr FunctionArrayElement::executeMap2(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const
+{
+    if (!context->getSettingsRef().precise_float_parsing)
+        return nullptr;
+
+    const ColumnArray * col_array = typeid_cast<const ColumnArray *>(arguments[0].column.get());
+    if (!col_array)
+        return nullptr;
+
+    const ColumnMap * col_map = typeid_cast<const ColumnMap *>(&col_array->getData());
+    if (!col_map)
+        return nullptr;
+
+    const ColumnArray * col_map_nested = &col_map->getNestedColumn();
+    const ColumnTuple * col_map_kv = checkAndGetColumn<ColumnTuple>(col_map_nested->getDataPtr().get());
+    ColumnPtr col_map_keys = col_map_kv->getColumnPtr(0);
+    ColumnPtr col_map_values = col_map_kv->getColumnPtr(1);
+
+    const DataTypeMap & map_type
+        = typeid_cast<const DataTypeMap &>(*typeid_cast<const DataTypeArray &>(*arguments[0].type).getNestedType());
+    const auto & key_type = map_type.getKeyType();
+    const auto & value_type = map_type.getValueType();
+
+    ColumnsWithTypeAndName temporary_results(2);
+    temporary_results[1] = arguments[1];
+
+    ColumnPtr result_key_column;
+    /// Calculate the function for the keys of the map.
+    {
+        ColumnWithTypeAndName array_of_keys;
+        array_of_keys.column
+            = ColumnArray::create(ColumnArray::create(col_map_keys, col_map_nested->getOffsetsPtr()), col_array->getOffsetsPtr());
+        array_of_keys.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeArray>(key_type));
+        temporary_results[0] = std::move(array_of_keys);
+
+        auto type = getReturnTypeImpl({temporary_results[0].type, temporary_results[1].type});
+        auto col = executeImpl(temporary_results, type, input_rows_count);
+        result_key_column = std::move(col);
+    }
+
+    /// Calculate the function for the values of the map
+    ColumnPtr result_value_column;
+    {
+        ColumnWithTypeAndName array_of_values;
+        array_of_values.column
+            = ColumnArray::create(ColumnArray::create(col_map_values, col_map_nested->getOffsetsPtr()), col_array->getOffsetsPtr());
+        array_of_values.type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeArray>(value_type));
+        temporary_results[0] = std::move(array_of_values);
+
+        auto type = getReturnTypeImpl({temporary_results[0].type, temporary_results[1].type});
+        auto col = executeImpl(temporary_results, type, input_rows_count);
+        result_value_column = std::move(col);
+    }
+
+    const auto & data_keys = typeid_cast<const ColumnArray &>(*result_key_column).getDataPtr();
+    const auto & data_values = typeid_cast<const ColumnArray &>(*result_value_column).getDataPtr();
+    const auto & offsets = typeid_cast<const ColumnArray &>(*result_key_column).getOffsetsPtr();
+    auto result_nested_column = ColumnArray::create(ColumnTuple::create(Columns{data_keys, data_values}), offsets);
+    return ColumnMap::create(std::move(result_nested_column));
+}
+
 ColumnPtr FunctionArrayElement::executeTuple(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const
 {
     const ColumnArray * col_array = typeid_cast<const ColumnArray *>(arguments[0].column.get());
-
     if (!col_array)
         return nullptr;
 
     const ColumnTuple * col_nested = typeid_cast<const ColumnTuple *>(&col_array->getData());
-
     if (!col_nested)
         return nullptr;
 
@@ -1211,6 +1995,7 @@ ColumnPtr FunctionArrayElement::executeImpl(const ColumnsWithTypeAndName & argum
 ColumnPtr FunctionArrayElement::perform(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type,
                                    ArrayImpl::NullMapBuilder & builder, size_t input_rows_count) const
 {
+    // std::cout << "perform:" << Block(arguments).dumpStructure() << ",,,,,,,result_type:" << result_type->getName() << std::endl;
     ColumnPtr res;
     if ((res = executeTuple(arguments, input_rows_count)))
     {
@@ -1221,6 +2006,17 @@ ColumnPtr FunctionArrayElement::perform(const ColumnsWithTypeAndName & arguments
                 builder.update(i);
         }
         return res;
+    }
+    else if ((res = executeMap2(arguments, input_rows_count)))
+    {
+        if (builder)
+        {
+            builder.initSink(input_rows_count);
+            for (size_t i = 0; i < input_rows_count; ++i)
+                builder.update(i);
+        }
+        return res;
+
     }
     else if (!isColumnConst(*arguments[1].column))
     {
@@ -1247,20 +2043,31 @@ ColumnPtr FunctionArrayElement::perform(const ColumnsWithTypeAndName & arguments
         if (index == 0u)
             throw Exception(ErrorCodes::ZERO_ARRAY_OR_TUPLE_INDEX, "Array indices are 1-based");
 
-        if (!((res = executeNumberConst<UInt8>(arguments, index, builder))
-            || (res = executeNumberConst<UInt16>(arguments, index, builder))
-            || (res = executeNumberConst<UInt32>(arguments, index, builder))
-            || (res = executeNumberConst<UInt64>(arguments, index, builder))
-            || (res = executeNumberConst<Int8>(arguments, index, builder))
-            || (res = executeNumberConst<Int16>(arguments, index, builder))
-            || (res = executeNumberConst<Int32>(arguments, index, builder))
-            || (res = executeNumberConst<Int64>(arguments, index, builder))
-            || (res = executeNumberConst<Float32>(arguments, index, builder))
-            || (res = executeNumberConst<Float64>(arguments, index, builder))
-            || (res = executeStringConst (arguments, index, builder))
-            || (res = executeGenericConst (arguments, index, builder))))
-        throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Illegal column {} of first argument of function {}",
-            arguments[0].column->getName(), getName());
+        if (!((res = executeNumberConst<UInt8>(arguments, index, builder)) || (res = executeNumberConst<UInt16>(arguments, index, builder))
+              || (res = executeNumberConst<UInt32>(arguments, index, builder))
+              || (res = executeNumberConst<UInt64>(arguments, index, builder))
+              || (res = executeNumberConst<Int8>(arguments, index, builder)) || (res = executeNumberConst<Int16>(arguments, index, builder))
+              || (res = executeNumberConst<Int32>(arguments, index, builder))
+              || (res = executeNumberConst<Int64>(arguments, index, builder))
+              || (res = executeNumberConst<Float32>(arguments, index, builder))
+              || (res = executeNumberConst<Float64>(arguments, index, builder))
+              || (res = executeArrayNumberConst<UInt8>(arguments, index, builder))
+              || (res = executeArrayNumberConst<UInt16>(arguments, index, builder))
+              || (res = executeArrayNumberConst<UInt32>(arguments, index, builder))
+              || (res = executeArrayNumberConst<UInt64>(arguments, index, builder))
+              || (res = executeArrayNumberConst<Int8>(arguments, index, builder))
+              || (res = executeArrayNumberConst<Int16>(arguments, index, builder))
+              || (res = executeArrayNumberConst<Int32>(arguments, index, builder))
+              || (res = executeArrayNumberConst<Int64>(arguments, index, builder))
+              || (res = executeArrayNumberConst<Float32>(arguments, index, builder))
+              || (res = executeArrayNumberConst<Float64>(arguments, index, builder))
+              || (res = executeStringConst(arguments, index, builder)) || (res = executeArrayStringConst(arguments, index, builder))
+              || (res = executeGenericConst(arguments, index, builder))))
+            throw Exception(
+                ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal column {} of first argument of function {}",
+                arguments[0].column->getName(),
+                getName());
     }
 
     return res;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Opt array element when input is array(map) 

优化原理：对Array(Map(K, V))执行arrayElement时，现有实现无法提前reserve，导致大量realloc和free操作，影响执行效率，可能导致OOM


arrayElement(Array(Map(K, V))) -> arrayElement(Array(Array(Tuple(K, V)))) -> arrayElement(Array(Tuple(Array(K), Array(V)))) -> arrayElement(Array(Array(K))) + ArrayElement(Array(Array(V)))  

当`arrayElement(Array(Array(K))`和`ArrayElement(Array(Array(V))) `中的K和V为String/Number类型时，可提前确定ColumnString和ColumnVector的大小并分配内存 