### PR TITLE
[GLUTEN-3908][CH]Improve insert range selective  for column nullable

### DIFF
--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -249,16 +249,8 @@ void ColumnNullable::insertRangeFrom(const IColumn & src, size_t start, size_t l
 void ColumnNullable::insertRangeSelective(const IColumn & src, const IColumn::Selector & selector, size_t selector_start, size_t length)
 {
     const ColumnNullable & nullable_col = static_cast<const ColumnNullable &>(src);
+    getNullMapColumn().insertRangeSelective(*nullable_col.null_map, selector, selector_start, length);
     getNestedColumn().insertRangeSelective(*nullable_col.nested_column, selector, selector_start, length);
-
-    if (!memoryIsZero(nullable_col.getNullMapData().data(), 0, nullable_col.size()))
-    {
-        getNullMapColumn().insertRangeSelective(*nullable_col.null_map, selector, selector_start, length);
-    }
-    else
-    {
-        getNullMapColumn().insertManyDefaults(length);
-    }
 }
 
 void ColumnNullable::insert(const Field & x)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The problem is described in issue https://github.com/oap-project/gluten/issues/3908, the memcmp in `ColumnNullable`'s function `insertRangeSelective` will decrease the shuffle write performance, and after remove the `memcmp` logical, the shuffle write performance improve as described in pr https://github.com/oap-project/gluten/pull/3909


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
