### PR TITLE
Support sum0 function

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSum.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSum.cpp
@@ -28,6 +28,16 @@ struct SumSimple
 };
 
 template <typename T>
+struct Sum0Simple
+{
+    using ResultType = std::conditional_t<is_decimal<T>,
+                                          std::conditional_t<std::is_same_v<T, Decimal256>, Decimal256, Decimal128>,
+                                          NearestFieldType<T>>;
+    using AggregateDataType = AggregateFunctionSumData<ResultType>;
+    using Function = AggregateFunctionSum<T, ResultType, AggregateDataType, AggregateFunctionTypeSum0>;
+};
+
+template <typename T>
 struct SumSameType
 {
     using ResultType = T;
@@ -44,6 +54,7 @@ struct SumKahan
 };
 
 template <typename T> using AggregateFunctionSumSimple = typename SumSimple<T>::Function;
+template <typename T> using AggregateFunctionSum0Simple = typename Sum0Simple<T>::Function;
 template <typename T> using AggregateFunctionSumWithOverflow = typename SumSameType<T>::Function;
 template <typename T> using AggregateFunctionSumKahan =
     std::conditional_t<is_decimal<T>, typename SumSimple<T>::Function, typename SumKahan<T>::Function>;
@@ -75,6 +86,8 @@ void registerAggregateFunctionSum(AggregateFunctionFactory & factory)
     factory.registerFunction("sum", createAggregateFunctionSum<AggregateFunctionSumSimple>, AggregateFunctionFactory::CaseInsensitive);
     factory.registerFunction("sumWithOverflow", createAggregateFunctionSum<AggregateFunctionSumWithOverflow>);
     factory.registerFunction("sumKahan", createAggregateFunctionSum<AggregateFunctionSumKahan>);
+    AggregateFunctionProperties properties = { .returns_default_when_only_null = true, .is_order_dependent = false };
+    factory.registerFunction("sum0", {createAggregateFunctionSum<AggregateFunctionSum0Simple>, properties}, AggregateFunctionFactory::CaseInsensitive);
 }
 
 }

--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -443,6 +443,7 @@ struct AggregateFunctionSumKahanData
 enum AggregateFunctionSumType
 {
     AggregateFunctionTypeSum,
+    AggregateFunctionTypeSum0,
     AggregateFunctionTypeSumWithOverflow,
     AggregateFunctionTypeSumKahan,
 };
@@ -459,6 +460,8 @@ public:
     {
         if constexpr (Type == AggregateFunctionTypeSum)
             return "sum";
+        else if constexpr (Type == AggregateFunctionTypeSum0)
+            return "sum0";
         else if constexpr (Type == AggregateFunctionTypeSumWithOverflow)
             return "sumWithOverflow";
         else if constexpr (Type == AggregateFunctionTypeSumKahan)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature

### Documentation entry for user-facing changes

Difference between sum and sum0:
If agg data is empty, sum(nullable_col) return \N, but sum0 return 0.
which code take effect:
```
AggregateFunctionProperties properties = { .returns_default_when_only_null = true, .is_order_dependent = false }
```

ClickHouse plan difference:
![image](https://github.com/Kyligence/ClickHouse/assets/23639010/f156aa67-af13-44f3-8297-ffe67b47b480)
