### PR TITLE
[GLUTEN-6016] Allow overflow when converting decimal to int like spark

### DIFF
--- a/src/Core/DecimalFunctions.h
+++ b/src/Core/DecimalFunctions.h
@@ -308,7 +308,7 @@ template <typename To, typename DecimalType, typename ReturnType>
 ReturnType convertToImpl(const DecimalType & decimal, UInt32 scale, To & result)
 {
     using DecimalNativeType = typename DecimalType::NativeType;
-    static constexpr bool throw_exception = std::is_void_v<ReturnType>;
+    // static constexpr bool throw_exception = std::is_void_v<ReturnType>;
 
     if constexpr (std::is_floating_point_v<To>)
     {
@@ -318,6 +318,8 @@ ReturnType convertToImpl(const DecimalType & decimal, UInt32 scale, To & result)
     {
         DecimalNativeType whole = getWholePart(decimal, scale);
 
+        /// Spark allows overflow when converting decimal to int
+        /*
         if constexpr (is_unsigned_v<To>)
         {
             if (whole < 0)
@@ -328,6 +330,7 @@ ReturnType convertToImpl(const DecimalType & decimal, UInt32 scale, To & result)
                     return ReturnType(true);
             }
         }
+        */
 
         result = static_cast<To>(whole);
     }
@@ -337,6 +340,8 @@ ReturnType convertToImpl(const DecimalType & decimal, UInt32 scale, To & result)
 
         const DecimalNativeType whole = getWholePart(decimal, scale);
 
+        /// Spark allows overflow when converting decimal to int
+        /*
         static const constexpr CastTo min_to = std::numeric_limits<To>::min();
         static const constexpr CastTo max_to = std::numeric_limits<To>::max();
 
@@ -347,6 +352,7 @@ ReturnType convertToImpl(const DecimalType & decimal, UInt32 scale, To & result)
             else
                 return ReturnType(true);
         }
+        */
 
         result = static_cast<CastTo>(whole);
     }


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow overflow when converting decimal to int like spark
