### PR TITLE
[GLUTEN-6977] Allow concat process Nullable(Array(T)) or Nullable(Map(K, V)) or Nullable(Tuple(T1, T2...))

### DIFF
--- a/src/Functions/concat.cpp
+++ b/src/Functions/concat.cpp
@@ -214,11 +214,11 @@ public:
     {
         if (arguments.size() == 1)
             return FunctionFactory::instance().getImpl("toString", context)->build(arguments);
-        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isArray(elem.type); }))
+        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isArray(removeNullable(elem.type)); }))
             return FunctionFactory::instance().getImpl("arrayConcat", context)->build(arguments);
-        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isMap(elem.type); }))
+        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isMap(removeNullable(elem.type)); }))
             return FunctionFactory::instance().getImpl("mapConcat", context)->build(arguments);
-        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isTuple(elem.type); }))
+        if (!arguments.empty() && std::ranges::all_of(arguments, [](const auto & elem) { return isTuple(removeNullable(elem.type)); }))
             return FunctionFactory::instance().getImpl("tupleConcat", context)->build(arguments);
         return std::make_unique<FunctionToFunctionBaseAdaptor>(
             FunctionConcat::create(context),


### PR DESCRIPTION

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow concat process Nullable(Array(T)) or Nullable(Map(K, V)) or Nullable(Tuple(T1, T2...))
