### PR TITLE
Rewrite datetime64 format logic. 

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1161,6 +1161,7 @@ class IColumn;
     M(DateTimeInputFormat, date_time_input_format, FormatSettings::DateTimeInputFormat::Basic, "Method to read DateTime from text input formats. Possible values: 'basic', 'best_effort' and 'best_effort_us'.", 0) \
     M(DateTimeOutputFormat, date_time_output_format, FormatSettings::DateTimeOutputFormat::Simple, "Method to write DateTime to text output. Possible values: 'simple', 'iso', 'unix_timestamp'.", 0) \
     M(IntervalOutputFormat, interval_output_format, FormatSettings::IntervalOutputFormat::Numeric, "Textual representation of Interval. Possible values: 'kusto', 'numeric'.", 0) \
+    M(Bool, datetime64_trim_suffix_zeros, false, "Trim suffix zeros when datetime64 cast to string", 0) \
     \
     M(Bool, input_format_ipv4_default_on_conversion_error, false, "Deserialization of IPv4 will use default values instead of throwing exception on conversion error.", 0) \
     M(Bool, input_format_ipv6_default_on_conversion_error, false, "Deserialization of IPV6 will use default values instead of throwing exception on conversion error.", 0) \

--- a/src/IO/WriteHelpers.h
+++ b/src/IO/WriteHelpers.h
@@ -819,10 +819,10 @@ inline void writeDateTime64FractionalText(typename DecimalType::NativeType fract
     static_assert(sizeof(data) >= MaxScale);
 
     for (Int32 pos = scale - 1; pos >= 0 && fractional; --pos, fractional /= DateTime64(10))
-    {
         data[pos] += fractional % DateTime64(10);
-    }
-    if constexpr (trim_suffix_zeros) {
+
+    if constexpr (trim_suffix_zeros)
+    {
         UInt32 last_none_zero_pos = 0;
         for (UInt32 pos = 0; pos < scale; ++pos)
         {
@@ -833,7 +833,9 @@ inline void writeDateTime64FractionalText(typename DecimalType::NativeType fract
         }
         size_t new_scale = (last_none_zero_pos > 3 ? 6 : 3);
         writeString(&data[0], new_scale, buf);
-    } else {
+    }
+    else
+    {
         writeString(&data[0], static_cast<size_t>(scale), buf);
     }
 }
@@ -978,13 +980,18 @@ inline void writeDateTimeText(DateTime64 datetime64, UInt32 scale, WriteBuffer &
     }
 
     writeDateTimeText<date_delimeter, time_delimeter, between_date_time_delimiter>(LocalDateTime(components.whole, time_zone), buf);
-    if constexpr (trim_suffix_zeros) {
-        if (scale > 0 && components.fractional != 0) {
+    if constexpr (trim_suffix_zeros)
+    {
+        if (scale > 0 && components.fractional != 0)
+        {
             buf.write(fractional_time_delimiter);
             writeDateTime64FractionalText<DateTime64, true>(components.fractional, scale, buf);
         }
-    } else {
-        if (scale > 0) {
+    }
+    else
+    {
+        if (scale > 0)
+        {
             buf.write(fractional_time_delimiter);
             writeDateTime64FractionalText<DateTime64, false>(components.fractional, scale, buf);
         }

--- a/src/IO/tests/gtest_DateTimeToString.cpp
+++ b/src/IO/tests/gtest_DateTimeToString.cpp
@@ -78,7 +78,7 @@ TEST(DateTimeToStringTest, RFC1123)
     ASSERT_EQ(out.str(), "Fri, 18 Mar 2005 01:58:31 GMT");
 }
 
-template <typename ValueType>
+template <typename ValueType, bool trim_suffix_zeros = false>
 class DateTimeToStringParamTestBase : public ::testing::TestWithParam<DateTimeToStringParamTestCase<ValueType>>
 {
 public:
@@ -99,7 +99,10 @@ public:
         }
         else if constexpr (std::is_same_v<ValueType, DateTime64WithScale>)
         {
-            writeDateTimeText(input.value, input.scale, out, DateLUT::instance(timezone_name));
+            if constexpr (trim_suffix_zeros)
+                writeDateTimeText<'-', ':', ' ', '.', true>(input.value, input.scale, out, DateLUT::instance(timezone_name));
+            else
+                writeDateTimeText(input.value, input.scale, out, DateLUT::instance(timezone_name));
         }
 
         ASSERT_EQ(expected, out.str());
@@ -126,6 +129,14 @@ class DateTimeToStringParamTestDateTime64 : public DateTimeToStringParamTestBase
 {};
 
 TEST_P(DateTimeToStringParamTestDateTime64, writeDateText)
+{
+    ASSERT_NO_FATAL_FAILURE(test(GetParam()));
+}
+
+class DateTimeToStringParamTestDateTime64TrimZeros : public DateTimeToStringParamTestBase<DateTime64WithScale, true>
+{};
+
+TEST_P(DateTimeToStringParamTestDateTime64TrimZeros, writeDateText)
 {
     ASSERT_NO_FATAL_FAILURE(test(GetParam()));
 }
@@ -212,3 +223,36 @@ INSTANTIATE_TEST_SUITE_P(DateTimeToString, DateTimeToStringParamTestDateTime64,
 //        },
     })
 );
+
+
+INSTANTIATE_TEST_SUITE_P(DateTimeToString, DateTimeToStringParamTestDateTime64TrimZeros,
+    ::testing::ValuesIn(std::initializer_list<DateTimeToStringParamTestCase<DateTime64WithScale>>
+    {
+         /// Inside basic LUT boundaries
+         {
+             "Zero DateTime64 with scale 0",
+             DateTime64WithScale{0, 0},
+             "1970-01-01 00:00:00"
+         },
+         {
+             "Zero DateTime64 with scale 6, fractional is trimmed",
+             DateTime64WithScale{0, 6},
+             "1970-01-01 00:00:00"
+         },
+         {
+             "DateTime64 with scale 3, fractional is trimmed",
+             DateTime64WithScale{NON_ZERO_TIME_T * 1000LL, 3},
+             "1979-12-31 10:17:36"
+         },
+         {
+             "DateTime64 with scale 6, fractional is partially trimmed",
+             DateTime64WithScale{120000, 6},
+             "1970-01-01 00:00:00.120"
+         },
+         {
+             "DateTime64 with scale 6, fractional is kept",
+             DateTime64WithScale{123456, 6},
+             "1970-01-01 00:00:00.123456"
+         },
+    })
+ );


### PR DESCRIPTION
Output scale is dynamic in (0, 3, 6) according to real scale. See changes in following examples.

1. 2012-01-01 00:11:22.000000 -> 2012-01-01 00:11:22
2. 2012-01-01 00:11:22.120000 -> 2012-01-01 00:11:22.120
3. 2012-01-01 00:11:22.123400 -> 2012-01-01 00:11:22.123400
