### PR TITLE
[GLUTEN-7311]A patch for supporting multiple aggregate phases in one step

### DIFF
--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -175,6 +175,30 @@ Block Aggregator::getHeader(bool final) const
     return params.getHeader(header, final);
 }
 
+static DataTypePtr
+getResultTypeForPartialAggregate(const Block & header, const AggregateDescription & aggregate, const DataTypes & argument_types)
+{
+    DataTypePtr type;
+    /// This could happen in gluten when there are multiple aggregate phases in one aggregation step.
+    /// For example, `select count(x), sum(distinct y) from t group by k`.
+    /// AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE and AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE
+    /// could be in the same aggregating step.
+    /// When the input is intermediate aggregate data
+    /// - There is a column in `header` of which name is same as `aggreaget.column_name`
+    /// - the output type must also be same as input (Since this is not a final stage)
+    const auto * input_col = header.findByName(aggregate.column_name);
+    if (input_col && typeid_cast<const DataTypeAggregateFunction *>(input_col->type.get()))
+    {
+        type = input_col->type;
+    }
+    else
+    {
+        type = std::make_shared<DataTypeAggregateFunction>(aggregate.function, argument_types, aggregate.parameters);
+    }
+
+    return type;
+}
+
 Block Aggregator::Params::getHeader(
     const Block & header, bool only_merge, const Names & keys, const AggregateDescriptions & aggregates, bool final)
 {
@@ -219,7 +243,7 @@ Block Aggregator::Params::getHeader(
             if (final)
                 type = aggregate.function->getResultType();
             else
-                type = std::make_shared<DataTypeAggregateFunction>(aggregate.function, argument_types, aggregate.parameters);
+                type = getResultTypeForPartialAggregate(header, aggregate, argument_types);
 
             res.insert({ type, aggregate.column_name });
         }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

Fix https://github.com/apache/incubator-gluten/issues/7311

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
