### PR TITLE
[GLUTEN-7387][CH] Enable parallel downloading for text and json

### DIFF
--- a/src/IO/ParallelReadBuffer.h
+++ b/src/IO/ParallelReadBuffer.h
@@ -30,6 +30,14 @@ private:
 public:
     ParallelReadBuffer(SeekableReadBuffer & input, ThreadPoolCallbackRunnerUnsafe<void> schedule_, size_t max_working_readers, size_t range_step_, size_t file_size);
 
+    ParallelReadBuffer(
+        std::unique_ptr<SeekableReadBuffer> input,
+        ThreadPoolCallbackRunnerUnsafe<void> schedule_,
+        size_t max_working_readers,
+        size_t range_step_,
+        size_t file_size);
+
+
     ~ParallelReadBuffer() override { finishAndWait(); }
 
     off_t seek(off_t off, int whence) override;
@@ -65,6 +73,7 @@ private:
 
     ThreadPoolCallbackRunnerUnsafe<void> schedule;
 
+    std::shared_ptr<SeekableReadBuffer> input_holder;
     SeekableReadBuffer & input;
     size_t file_size;
     size_t range_step;
@@ -97,4 +106,10 @@ std::unique_ptr<ParallelReadBuffer> wrapInParallelReadBufferIfSupported(
     ReadBuffer & buf, ThreadPoolCallbackRunnerUnsafe<void> schedule, size_t max_working_readers,
     size_t range_step, size_t file_size);
 
+std::unique_ptr<ReadBuffer> wrapInParallelReadBufferIfSupported(
+    std::unique_ptr<ReadBuffer> buf,
+    ThreadPoolCallbackRunnerUnsafe<void> schedule,
+    size_t max_working_readers,
+    size_t range_step,
+    size_t file_size);
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Enable parallel downloading for text and json.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
