### PR TITLE
Add comile ignored Wcast-qual in xsimd_wrapper.h

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/xsimd_wrapper.h
+++ b/src/Processors/Formats/Impl/Parquet/xsimd_wrapper.h
@@ -11,5 +11,6 @@ _Pragma("clang diagnostic ignored \"-Wshorten-64-to-32\"")
 _Pragma("clang diagnostic ignored \"-Wfloat-conversion\"")
 _Pragma("clang diagnostic ignored \"-Wunused-but-set-variable\"")
 _Pragma("clang diagnostic ignored \"-Wundef\"")
+_Pragma("clang diagnostic ignored \"-Wcast-qual\"")
 #include <xsimd/xsimd.hpp>
 _Pragma("clang diagnostic pop")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

change compile level int xsimd_wrapper.h to use xsimd plugin.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
