### PR TITLE
[GLUTEN-10961] For join without any on condition, we do not need to maintain used f…

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -1655,6 +1655,10 @@ bool HashJoin::needUsedFlagsForPerRightTableRow(std::shared_ptr<TableJoin> table
     if (table_join_->kind() == JoinKind::Cross)
         return false;
 
+    // Gluten patch: For join without any on condiition, we do not need to maintain used flags.
+    if (table_join_->getClauses().empty())
+        return false;
+
     if (!table_join_->oneDisjunct())
         return true;
     /// If it'a a all right join with inequal conditions, we need to mark each row


### PR DESCRIPTION
If a join without any join clause, it doesn't need used flags for per right table
```sql
select k1, k2 from t1 left join t2
```

Fix https://github.com/apache/incubator-gluten/issues/10961