### PR TITLE
fix(hdfs): EC-safe reads for Parquet/ORC and libhdfs3 striped reader

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -44,3 +44,4 @@ no_warning(thread-safety-negative) # experimental flag, too many false positives
 no_warning(unsafe-buffer-usage) # too aggressive
 no_warning(switch-default) # conflicts with "defaults in a switch covering all enum values"
 no_warning(nrvo) # not eliding copy on return - too aggressive
+no_warning(missing-noreturn) # Clang: many throw-only overrides; marking [[noreturn]] on all of them is impractical

--- a/contrib/libhdfs3-cmake/CMakeLists.txt
+++ b/contrib/libhdfs3-cmake/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SRCS
     "${HDFS3_SOURCE_DIR}/client/RawErasureCoderFactory.cpp"
     "${HDFS3_SOURCE_DIR}/client/RawErasureDecoder.cpp"
     "${HDFS3_SOURCE_DIR}/client/RawErasureEncoder.cpp"
+    "${HDFS3_SOURCE_DIR}/client/PositionStripeReader.cpp"
     "${HDFS3_SOURCE_DIR}/client/StatefulStripeReader.cpp"
     "${HDFS3_SOURCE_DIR}/client/StripeReader.cpp"
     "${HDFS3_SOURCE_DIR}/client/StripedBlockUtil.cpp"

--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -124,6 +124,13 @@ void ORCInputStream::read(void * buf, UInt64 length, UInt64 offset)
         {
             size_t bytes_to_read = length - bytes_read;
             size_t n = in.readBigAt(reinterpret_cast<char *>(buf) + bytes_read, bytes_to_read, offset + bytes_read, nullptr);
+            if (n == 0)
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "ORC readBigAt returned no bytes at offset {} ({} bytes remaining of {}); input may be truncated or corrupted",
+                    offset + bytes_read,
+                    bytes_to_read,
+                    length);
             bytes_read += n;
         }
     }

--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.cpp
@@ -96,9 +96,12 @@ extern const int ARGUMENT_OUT_OF_BOUND;
 
 
 ORCInputStream::ORCInputStream(SeekableReadBuffer & in_, size_t file_size_, bool use_prefetch)
-    : in(in_), file_size(file_size_), supports_read_at(use_prefetch && in_.supportsReadAt())
+    : in(in_)
+    , file_size(file_size_)
+    , use_offset_based_read(in_.supportsReadAt())
+    , use_async_prefetch(use_prefetch && use_offset_based_read)
 {
-    if (supports_read_at)
+    if (use_async_prefetch)
         async_runner = threadPoolCallbackRunnerUnsafe<void>(getIOThreadPool().get(), "ORCFile");
 }
 
@@ -114,7 +117,7 @@ UInt64 ORCInputStream::getNaturalReadSize() const
 
 void ORCInputStream::read(void * buf, UInt64 length, UInt64 offset)
 {
-    if (supports_read_at)
+    if (use_offset_based_read)
     {
         size_t bytes_read = 0;
         while (bytes_read < length)
@@ -134,7 +137,7 @@ void ORCInputStream::read(void * buf, UInt64 length, UInt64 offset)
 
 std::future<void> ORCInputStream::readAsync(void * buf, uint64_t length, uint64_t offset)
 {
-    if (supports_read_at)
+    if (use_async_prefetch)
     {
         return async_runner(
             [this, buf, length, offset]

--- a/src/Processors/Formats/Impl/NativeORCBlockInputFormat.h
+++ b/src/Processors/Formats/Impl/NativeORCBlockInputFormat.h
@@ -33,7 +33,10 @@ public:
 protected:
     SeekableReadBuffer & in;
     size_t file_size;
-    bool supports_read_at;
+    /// Use offset-based reads (ReadBuffer::readBigAt, e.g. hdfs pread) instead of seek+read; needed for ORC tail on HDFS EC.
+    bool use_offset_based_read;
+    /// Async wrapper only when caller enabled prefetch and the buffer supports read-at.
+    bool use_async_prefetch;
     ThreadPoolCallbackRunnerUnsafe<void> async_runner;
 
     std::string name = "ORCInputStream";


### PR DESCRIPTION
- Add PositionStripeReader.cpp to libhdfs3-cmake SRCS (fix undefined PositionStripeReader symbol when linking StripedInputStreamImpl).
- HDFS ReadBufferBuilder: do not trust Substrait properties.filesize for Parquet/ORC (incl. Iceberg); always stat real length for footer/postscript.
- Parquet: prefer RandomAccessFileFromRandomAccessReadBuffer when readBigAt is available so footer ReadAt uses pread, not seek+read.
- ORC (Gluten): OrcUtil path mirrors the same Arrow RandomAccessFile choice where applicable.
- NativeORCBlockInputFormat: decouple offset-based read (readBigAt) from use_prefetch so Gluten (use_prefetch=false) still uses pread on HDFS EC; rename flag to use_offset_based_read for clarity.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Bug Fix (user-visible misbehavior in an official stable release)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
